### PR TITLE
Pivot cndb to a graph knowledge base for codebases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ serde_json = "1.0"
 bson = "2.8"
 bincode = "1.3"
 thiserror = "1.0"
+crc32fast = "1.4"
 
 # Vector search (rust-bert, hnsw) is deferred to v1 — see docs/ARCHITECTURE.md.
 # rust-bert pulls torch-sys, whose build script downloads libtorch; it fails to
@@ -17,4 +18,5 @@ thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.5"
+crc32fast = "1.4"
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ serde_json = "1.0"
 bson = "2.8"
 bincode = "1.3"
 thiserror = "1.0"
-rust-bert = "0.21"
-hnsw = "0.11"
+
+# Vector search (rust-bert, hnsw) is deferred to v1 — see docs/ARCHITECTURE.md.
+# rust-bert pulls torch-sys, whose build script downloads libtorch; it fails to
+# build and rules out a single portable binary. The v1 replacement is a
+# statically linked ONNX/Candle backend.
 
 [dev-dependencies]
 criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,20 @@ let callers = db.callers("cndb::storage::append_record", Depth(2))?;
 
 ## Status
 
-Early development. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the
-full design, the graph and file-format specifications, and the roadmap.
+Early development. **M1, the storage core, is implemented**: the `.cndb` file
+format, the append-only record log, the document offset map, the BSON codec,
+and crash-safe commit and recovery.
+
+```rust
+let mut db = cndb::Cndb::open("graph.cndb")?;
+let id = db.insert(&json!({ "kind": "Function", "name": "parse_header" }))?;
+db.commit()?;
+assert_eq!(db.get(id)?["kind"], "Function");
+```
+
+The graph model, extraction, query engine, CLI and bindings follow in M2–M6.
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full design, the
+file-format specification and the roadmap.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# cndb - ContextDB
-Single file database optimized for storing and retrieving contextual data, relevant for your CLI shell.
+# cndb — ContextDB
+
+A single-file, embedded **graph knowledge base for codebases**.
+
+cndb reads a repository, extracts its structure into a graph of symbols and
+relationships, and stores it in one portable `.cndb` file. Coding agents and
+applications query that graph to answer structural questions about code —
+*who calls this*, *what breaks if I change it*, *what do I need to read to
+understand this subsystem* — without crawling the filesystem.
+
+cndb is a storage engine in its own right, an alternative to SQLite rather than
+a layer on top of one. No server, no daemon, no network protocol, no third-party
+database underneath.
+
+## Design
+
+- **One file.** The entire graph lives in a single `.cndb` file you can copy
+  between machines.
+- **Local-first.** Runs in-process with zero runtime dependencies. Source code
+  never leaves the machine.
+- **Deterministic.** Structure is extracted with tree-sitter, so the same commit
+  produces the same graph on every machine. Heuristically resolved edges are
+  tagged as such rather than reported as fact.
+- **No MCP.** Applications get real in-process function calls. Agents shell out
+  to one static binary that prints JSON — no server to register, no port, no
+  editor restart.
+
+## Planned interface
+
+```bash
+cndb init                      # build the graph for this repo
+cndb sync                      # incremental re-index of changed files
+cndb explore "auth flow"       # relevant symbols, with call paths and snippets
+cndb callers parse_header      # who calls this
+cndb impact parse_header       # blast radius of a change
+cndb path handle_request write_record
+```
+
+```rust
+let db = Cndb::open(".cndb/graph.cndb")?;
+let callers = db.callers("cndb::storage::append_record", Depth(2))?;
+```
+
+## Status
+
+Early development. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the
+full design, the graph and file-format specifications, and the roadmap.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,28 +175,31 @@ separate binaries' worth of concerns but ship in one binary.
 ### 3.1 File layout
 
 ```
-┌──────────────────────────────────────────────────────────┐
-│ HEADER SLOT A  (64 bytes)                                │
-│ HEADER SLOT B  (64 bytes)                                │
-│   magic       [u8; 4]  "CNDB"                            │
-│   version     u32      0x0003_0000                       │
-│   generation  u64      monotonic commit counter          │
-│   master_ptr  u64      byte offset of master index block  │
-│   master_len  u64      length of master index block       │
-│   log_end     u64      first free byte in the record log  │
-│   crc32       u32      checksum over the preceding fields │
-│   reserved    [u8; 24]                                    │
-├──────────────────────────────────────────────────────────┤
-│ RECORD LOG  (append-only, grows forward)                 │
-│   [len u32][kind u8][crc32 u32][BSON payload …]          │
-│   [len u32][kind u8][crc32 u32][BSON payload …]          │
-│   …                                                      │
-│   kind: 0 = Node, 1 = Edge, 2 = Blob, 3 = Tombstone      │
-├──────────────────────────────────────────────────────────┤
-│ MASTER INDEX BLOCK  (bincode, rewritten on each commit)  │
-│   see §3.3                                               │
-└──────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────┐
+│ HEADER SLOT A   bytes   0..64                                  │
+│ HEADER SLOT B   bytes  64..128                                 │
+│    0..4   magic       [u8; 4]  "CNDB"                          │
+│    4..8   version     u32      0x0003_0000                     │
+│    8..16  generation  u64      monotonic commit counter        │
+│   16..24  master_ptr  u64      offset of the master index      │
+│   24..32  master_len  u64      length of the master payload    │
+│   32..40  log_end     u64      first free byte of the log      │
+│   40..44  crc32       u32      checksum over the whole slot    │
+│   44..64  reserved    [u8; 20] zeroed, covered by the checksum │
+├────────────────────────────────────────────────────────────────┤
+│ RECORD LOG   bytes 128..log_end   (append-only, grows forward) │
+│   [len u32][kind u8][crc32 u32][payload …]                     │
+│   [len u32][kind u8][crc32 u32][payload …]                     │
+│   …                                                            │
+│   kind: 0 Node · 1 Edge · 2 Blob · 3 Tombstone · 4 MasterIndex │
+│   The live master index is the last record; superseded ones    │
+│   remain inline as dead space until compaction (§3.4).         │
+└────────────────────────────────────────────────────────────────┘
 ```
+
+The checksum is computed over all 64 bytes with the `crc32` field itself
+zeroed, so the reserved bytes are covered too and a future version cannot put
+unprotected data there.
 
 ### 3.2 Atomic commit via header ping-pong
 
@@ -204,38 +207,64 @@ v0.2.0 specified overwriting a single header in place. A 64-byte write inside
 one sector is atomic on real hardware, but that is a hardware assumption rather
 than a guarantee. v0.3.0 uses two header slots instead:
 
-1. Append all new records to the log. `fsync`.
-2. Append a fresh master index block after them. `fsync`.
+1. Append all new records at `log_end`. `fsync`.
+2. Append the master index **as an ordinary log record**. `fsync`.
 3. Write a header with `generation + 1` into the **older** of the two slots.
    `fsync`.
 
-On open, read both slots, discard any with a bad magic or CRC, and take the
-survivor with the highest `generation`. A crash at any point leaves the previous
-generation's header fully intact and the partially written bytes beyond
-`log_end` are simply overwritten by the next append. No write-ahead log needed,
-and no torn-header failure mode.
+Step 3 is the commit point. On open, read both slots, discard any with a bad
+magic, bad version or bad CRC, and take the survivor with the highest
+`generation`.
+
+Writing the master index into the log rather than into a reserved trailing
+region is what makes step 1 safe. Appends always start past the live master
+record, so the generation currently on disk keeps a readable index for the
+entire write; scans skip the record by kind. Had the index lived in fixed
+space at the end of the file, step 1 would overwrite the very block the live
+header still points at, and a crash between steps 1 and 3 would leave a valid
+header addressing shredded bytes.
+
+A crash before step 3 therefore leaves the previous header intact, still
+pointing at its own master index, with every new byte sitting beyond the old
+`log_end` where the next append overwrites it. A crash *during* step 3 tears at
+most one slot and the other survives. No write-ahead log is required, which is
+why issue #14's optional WAL does not appear here.
+
+Recovery rewinds to `log_end`; it does not shorten the file. Abandoned bytes
+past `log_end` are never read and are overwritten by subsequent appends, so
+repeated crashes reuse the same space rather than accumulating. Physically
+returning it to the filesystem is compaction's job (§3.4).
 
 ### 3.3 Master index block
 
-One bincode-serialized struct holding every in-memory index:
+One bincode-serialized struct holding every in-memory index. M1 implements the
+first three fields; the rest arrive with the graph and query engines.
 
 ```rust
 pub struct MasterIndex {
+    // ── M1 ──────────────────────────────────────────────────────────
     /// DocId -> byte offset in the record log
-    offsets:  HashMap<DocId, u64>,
-    /// Outgoing adjacency: NodeId -> edges leaving it
-    out_adj:  HashMap<NodeId, Vec<EdgeRef>>,
-    /// Incoming adjacency: NodeId -> edges arriving at it
-    in_adj:   HashMap<NodeId, Vec<EdgeRef>>,
-    /// Fully-qualified symbol name -> candidate nodes
-    by_name:  HashMap<String, Vec<NodeId>>,
-    /// FileId -> every doc extracted from that file (for incremental sync)
-    by_file:  HashMap<FileId, Vec<DocId>>,
-    /// Inverted index over names, signatures and doc comments
-    fts:      InvertedIndex,
+    offsets:     HashMap<DocId, u64>,
     /// Tombstoned doc ids, excluded from all reads
-    dead:     HashSet<DocId>,
-    meta:     DbMeta,
+    dead:        HashSet<DocId>,
+    /// Next id to hand out; never reused, even after a delete
+    next_doc_id: u64,
+
+    // ── M2: graph model ─────────────────────────────────────────────
+    /// Outgoing adjacency: NodeId -> edges leaving it
+    out_adj:     HashMap<NodeId, Vec<EdgeRef>>,
+    /// Incoming adjacency: NodeId -> edges arriving at it
+    in_adj:      HashMap<NodeId, Vec<EdgeRef>>,
+    /// Fully-qualified symbol name -> candidate nodes
+    by_name:     HashMap<String, Vec<NodeId>>,
+
+    // ── M3/M5: extraction and incremental sync ──────────────────────
+    /// FileId -> every doc extracted from that file
+    by_file:     HashMap<FileId, Vec<DocId>>,
+
+    // ── M4: query engine ────────────────────────────────────────────
+    /// Inverted index over names, signatures and doc comments
+    fts:         InvertedIndex,
 }
 
 pub struct EdgeRef {
@@ -244,6 +273,10 @@ pub struct EdgeRef {
     edge_id: DocId,
 }
 ```
+
+bincode is not self-describing, so each of those additions changes the layout.
+`FORMAT_VERSION` in the header is the guard: a file written under an earlier
+layout is rejected at open rather than misread.
 
 `EdgeRef` vectors are kept sorted by `kind`, so a kind-filtered neighbor lookup
 is a binary search plus a contiguous slice — the hot path for every traversal.
@@ -455,10 +488,10 @@ cndb stats
 
 ## 7. Roadmap
 
-| Milestone | Scope | Existing issues |
-|---|---|---|
-| **M1 — Storage core** | header ping-pong, record log, offset map, BSON codec, commit/recover | #5, #6, #7, #8, #14 |
-| **M2 — Graph model** | node/edge types, adjacency + name indexes, filters, traversal primitives | #9, #15 (reframed) |
+| Milestone | Scope | Existing issues | Status |
+|---|---|---|---|
+| **M1 — Storage core** | header ping-pong, record log, offset map, BSON codec, commit/recover | #5, #6, #7, #8, #14 | **done** |
+| **M2 — Graph model** | node/edge types, adjacency + name indexes, filters, traversal primitives | #9, #15 (reframed) | next |
 | **M3 — Extraction** | file walk, tree-sitter for 5 languages, resolution pass, confidence | new |
 | **M4 — Query engine** | FTS index, explore/callers/callees/impact/path/context | new |
 | **M5 — CLI + sync** | binary, JSON output, incremental sync, compaction | new |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,415 @@
+# cndb — Architecture
+
+**Version:** 0.3.0
+**Status:** Draft
+**Supersedes:** the v0.2.0 technical design in issue #1
+
+---
+
+## 1. What cndb is
+
+cndb is a **single-file, embedded graph knowledge base for codebases**.
+
+It reads a repository, extracts its structure into a graph of symbols and
+relationships, and stores that graph in one portable `.cndb` file. Coding
+agents and applications query it to answer structural questions about code —
+*who calls this*, *what breaks if I change it*, *what do I need to read to
+understand this subsystem* — without crawling the filesystem.
+
+cndb is a storage engine in its own right. It is an alternative to SQLite, not
+a layer on top of one. There is no server, no daemon, no network protocol, and
+no third-party database underneath it.
+
+### 1.1 What changed from v0.2.0
+
+v0.2.0 described a hybrid **document + vector** database validated against an
+e-commerce workload (order history, 10M synthetic orders, concurrent HTTP load).
+v0.3.0 keeps the storage thesis and replaces the data model and the workload.
+
+| | v0.2.0 | v0.3.0 |
+|---|---|---|
+| Primary model | BSON documents | Graph of nodes + edges (stored as documents) |
+| Primary retrieval | Vector similarity (HNSW) | Graph traversal + full-text |
+| Target workload | E-commerce OLTP, 100 concurrent users | Code intelligence, single local process |
+| Primary consumer | Application code | Coding agents and application code |
+| Vectors | Core, day one | Deferred to v1, behind a feature flag |
+
+Unchanged, and still the point of the project:
+
+- Everything in one `.cndb` file you can copy between machines
+- Local-first, in-process, zero runtime dependencies
+- Append-only log with an atomically committed index block
+- Custom binary format, no external database
+
+### 1.2 Non-goals for v0
+
+- Distributed or networked operation
+- Multi-writer concurrency (single writer, multiple readers)
+- Vector search and embeddings (v1)
+- LLM-driven extraction (v1 — see §5.4)
+- MCP server (deliberately never — see §6)
+
+---
+
+## 2. The three engines
+
+```
+        ┌────────────────────────────────────────────────┐
+        │  cndb-query   — the bridge to LLMs / callers   │
+        │                                                │
+        │  explore · callers · callees · impact · path   │
+        │  Rust API  ·  CLI (JSON on stdout)  ·  FFI     │
+        └───────────────────────┬────────────────────────┘
+                                │  in-process function calls
+        ┌───────────────────────▼────────────────────────┐
+        │  cndb-graph   — the graph knowledge base       │
+        │                                                │
+        │  node/edge model · adjacency index · FTS index │
+        │  document collections · offset map · filters   │
+        └───────────────────────┬────────────────────────┘
+                                │
+        ┌───────────────────────▼────────────────────────┐
+        │  cndb-store   — the storage engine             │
+        │                                                │
+        │  single file · append-only log · master index  │
+        │  atomic commit · compaction · crash recovery   │
+        └───────────────────────┬────────────────────────┘
+                                │
+                        ┌───────▼────────┐
+                        │  graph.cndb    │
+                        └────────────────┘
+
+        ┌────────────────────────────────────────────────┐
+        │  cndb-extract — reads and understands code     │
+        │                                                │
+        │  file walk · tree-sitter parse · resolution    │
+        │  writes nodes + edges ─────────────────────────┼──▶ cndb-graph
+        └────────────────────────────────────────────────┘
+```
+
+`cndb-extract` is a **producer**: it runs at `init`/`sync` time and writes into
+the graph. `cndb-query` is a **consumer**: it reads and never writes. They are
+separate binaries' worth of concerns but ship in one binary.
+
+---
+
+## 3. Storage engine (`cndb-store`)
+
+### 3.1 File layout
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ HEADER SLOT A  (64 bytes)                                │
+│ HEADER SLOT B  (64 bytes)                                │
+│   magic       [u8; 4]  "CNDB"                            │
+│   version     u32      0x0003_0000                       │
+│   generation  u64      monotonic commit counter          │
+│   master_ptr  u64      byte offset of master index block  │
+│   master_len  u64      length of master index block       │
+│   log_end     u64      first free byte in the record log  │
+│   crc32       u32      checksum over the preceding fields │
+│   reserved    [u8; 24]                                    │
+├──────────────────────────────────────────────────────────┤
+│ RECORD LOG  (append-only, grows forward)                 │
+│   [len u32][kind u8][crc32 u32][BSON payload …]          │
+│   [len u32][kind u8][crc32 u32][BSON payload …]          │
+│   …                                                      │
+│   kind: 0 = Node, 1 = Edge, 2 = Blob, 3 = Tombstone      │
+├──────────────────────────────────────────────────────────┤
+│ MASTER INDEX BLOCK  (bincode, rewritten on each commit)  │
+│   see §3.3                                               │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Atomic commit via header ping-pong
+
+v0.2.0 specified overwriting a single header in place. A 64-byte write inside
+one sector is atomic on real hardware, but that is a hardware assumption rather
+than a guarantee. v0.3.0 uses two header slots instead:
+
+1. Append all new records to the log. `fsync`.
+2. Append a fresh master index block after them. `fsync`.
+3. Write a header with `generation + 1` into the **older** of the two slots.
+   `fsync`.
+
+On open, read both slots, discard any with a bad magic or CRC, and take the
+survivor with the highest `generation`. A crash at any point leaves the previous
+generation's header fully intact and the partially written bytes beyond
+`log_end` are simply overwritten by the next append. No write-ahead log needed,
+and no torn-header failure mode.
+
+### 3.3 Master index block
+
+One bincode-serialized struct holding every in-memory index:
+
+```rust
+pub struct MasterIndex {
+    /// DocId -> byte offset in the record log
+    offsets:  HashMap<DocId, u64>,
+    /// Outgoing adjacency: NodeId -> edges leaving it
+    out_adj:  HashMap<NodeId, Vec<EdgeRef>>,
+    /// Incoming adjacency: NodeId -> edges arriving at it
+    in_adj:   HashMap<NodeId, Vec<EdgeRef>>,
+    /// Fully-qualified symbol name -> candidate nodes
+    by_name:  HashMap<String, Vec<NodeId>>,
+    /// FileId -> every doc extracted from that file (for incremental sync)
+    by_file:  HashMap<FileId, Vec<DocId>>,
+    /// Inverted index over names, signatures and doc comments
+    fts:      InvertedIndex,
+    /// Tombstoned doc ids, excluded from all reads
+    dead:     HashSet<DocId>,
+    meta:     DbMeta,
+}
+
+pub struct EdgeRef {
+    kind:    EdgeKind,
+    other:   NodeId,
+    edge_id: DocId,
+}
+```
+
+`EdgeRef` vectors are kept sorted by `kind`, so a kind-filtered neighbor lookup
+is a binary search plus a contiguous slice — the hot path for every traversal.
+
+Storing adjacency in the index rather than scanning edge documents is the single
+decision that makes graph traversal viable on this format. A `callers` query
+touches the index and then reads only the documents it actually returns.
+
+### 3.4 Deletes and compaction
+
+The log is append-only, so updates and deletes are tombstones. `sync` on a
+changed file tombstones everything in `by_file[file_id]` and appends fresh
+records. When `dead.len() / total` crosses a threshold (default 0.3), compaction
+rewrites live records into a sibling file and renames it into place.
+
+---
+
+## 4. Graph model (`cndb-graph`)
+
+Nodes and edges are documents in reserved collections. The graph layer is a
+typed view over the document engine, not a separate storage path.
+
+### 4.1 Node kinds
+
+`File` · `Module` · `Function` · `Method` · `Class` · `Struct` · `Interface`
+(trait/protocol) · `Enum` · `TypeAlias` · `Constant` · `Test`
+
+```rust
+pub struct Node {
+    id:             NodeId,
+    kind:           NodeKind,
+    name:           String,        // `parse_header`
+    qualified_name: String,        // `cndb::storage::file_format::parse_header`
+    language:       Language,
+    file:           FileId,
+    span:           Span,          // byte + line range, for snippet extraction
+    signature:      Option<String>,
+    doc:            Option<String>,
+    hash:           u64,           // content hash, for change detection
+}
+```
+
+### 4.2 Edge kinds
+
+| Kind | Meaning |
+|---|---|
+| `CONTAINS` | file → symbol, class → method, module → module |
+| `CALLS` | function → function it invokes |
+| `IMPORTS` | file/module → module it imports |
+| `IMPLEMENTS` | type → interface/trait it implements |
+| `EXTENDS` | type → supertype |
+| `REFERENCES` | any symbol → any symbol mentioned but not called |
+| `TESTS` | test → symbol under test |
+
+```rust
+pub struct Edge {
+    id:         EdgeId,
+    kind:       EdgeKind,
+    from:       NodeId,
+    to:         NodeId,
+    confidence: Confidence,   // Extracted | Inferred(f32)
+    span:       Option<Span>, // the call site itself
+}
+```
+
+### 4.3 Confidence is not optional
+
+Tree-sitter tells you *"there is a call to the identifier `parse` at this
+byte range."* It does not tell you *which* `parse`. Resolution is a separate
+pass (§5.3) and it is frequently ambiguous — dynamic dispatch, duck typing,
+re-exports, generics.
+
+Every edge therefore carries provenance:
+
+- `Extracted` — syntactically unambiguous. A direct call to a name with exactly
+  one visible definition; an import with a resolvable path.
+- `Inferred(score)` — resolved heuristically among several candidates.
+
+Query results expose this, and callers can filter on it. Reporting a guessed
+call edge as fact is how a code intelligence tool loses trust, and it is why
+this field exists in v0 rather than being retrofitted alongside LLM extraction
+in v1.
+
+---
+
+## 5. Extraction engine (`cndb-extract`)
+
+### 5.1 Deterministic by design
+
+v0 extraction is **tree-sitter only**. No LLM is involved in building the graph.
+
+This is a deliberate constraint, not a limitation to be lifted at the first
+opportunity:
+
+- **Reproducible.** The same commit produces a byte-identical graph on every
+  machine. `impact` results are only trustworthy if they are stable.
+- **Fast.** Parsing is milliseconds per file, which is what makes save-triggered
+  incremental sync possible at all.
+- **Free.** No API keys, no per-index cost, no network. Indexing a large
+  monorepo costs nothing.
+- **Private.** Source code never leaves the machine.
+
+### 5.2 Pipeline
+
+```
+walk repo (respect .gitignore)
+  └─▶ detect language by extension
+       └─▶ parse with tree-sitter grammar
+            └─▶ run per-language queries → local symbols + raw references
+                 └─▶ global resolution pass
+                      └─▶ append Node/Edge records, rebuild indexes, commit
+```
+
+Languages for v0: **Rust, TypeScript, JavaScript, Python, Go**. Grammars are
+compiled into the binary, so there is no runtime grammar download and no
+per-machine variation.
+
+### 5.3 Resolution pass
+
+Parsing is per-file and embarrassingly parallel. Resolution is global and runs
+once all files are parsed:
+
+1. Build the qualified-name index from every definition found.
+2. Resolve each file's imports to concrete modules, producing `IMPORTS` edges.
+3. For each raw reference, compute the candidate set from the referencing file's
+   visible scope: locals → file scope → imported names → crate/package root.
+4. Exactly one candidate → `CALLS`/`REFERENCES` edge, `Extracted`.
+   Several candidates → `Inferred(1/n)`, dropped below a floor (default 0.2).
+   Zero candidates → recorded as an external/unresolved reference, not an edge.
+
+### 5.4 Where the LLM fits (v1, not v0)
+
+The interpretation layer is additive and sits strictly on top of the facts
+layer. It never rewrites extracted structure — it adds `Concept` nodes,
+subsystem summaries, and cross-language edges that no parser can see (a handler
+named in a YAML config, a route string matched to a function).
+
+The intended provider is whatever coding agent is **already installed on the
+user's machine**, invoked headlessly:
+
+```
+~/.claude/  → claude -p …          ~/.codex/ → codex exec …
+~/.gemini/  → gemini -p …          ollama    → fully local
+```
+
+Behind an `LlmProvider` trait, with a direct-API-key backend as the fallback.
+The user already pays for their agent subscription, so enrichment costs them
+nothing extra and requires no key management. This is why agent detection is
+worth building — but it enriches a graph that is already complete and correct
+without it.
+
+---
+
+## 6. Query engine (`cndb-query`)
+
+### 6.1 Two consumers, two surfaces, no MCP
+
+**Library consumers** — applications, and the Bun/Node bindings tracked in
+issue #3 — get genuine in-process function calls. The SQLite model:
+
+```rust
+let db = Cndb::open(".cndb/graph.cndb")?;
+let callers = db.callers("cndb::storage::append_record", Depth(2))?;
+```
+
+**Agent consumers** — Claude Code, Cursor, Codex — shell out to a single static
+binary that writes JSON to stdout. No daemon, no port, no protocol handshake,
+no config file to edit, no editor restart.
+
+MCP is the thing we are choosing not to be. It requires a server process, a
+registration step, and a client that speaks the protocol. A CLI that prints JSON
+works in every agent that can run a command, which is all of them.
+
+### 6.2 Operations
+
+| Command | Semantics |
+|---|---|
+| `explore <query>` | FTS seeds, ranked by relevance × degree centrality, expanded 1–2 hops, returned with source snippets |
+| `callers <symbol>` | reverse traversal of `CALLS`, bounded depth |
+| `callees <symbol>` | forward traversal of `CALLS`, bounded depth |
+| `impact <symbol>` | transitive reverse reachability over `CALLS` ∪ `REFERENCES`; returns affected symbols, files, and tests |
+| `path <a> <b>` | bidirectional BFS between two symbols |
+| `context <symbol>` | the minimal read-set to understand a symbol: definition, callees, types, tests |
+| `stats` | node/edge counts by kind, languages, staleness |
+
+Every command takes `--json`. Snippets are read from the source file by span at
+query time, so the graph stores locations rather than duplicated source.
+
+### 6.3 CLI shape
+
+```
+cndb init            # build the graph for the current repo → .cndb/graph.cndb
+cndb sync            # incremental re-index of changed files
+cndb explore "auth flow" --json
+cndb impact parse_header --depth 3 --json
+cndb callers Cndb::open
+cndb path handle_request write_record
+cndb stats
+```
+
+---
+
+## 7. Roadmap
+
+| Milestone | Scope | Existing issues |
+|---|---|---|
+| **M1 — Storage core** | header ping-pong, record log, offset map, BSON codec, commit/recover | #5, #6, #7, #8, #14 |
+| **M2 — Graph model** | node/edge types, adjacency + name indexes, filters, traversal primitives | #9, #15 (reframed) |
+| **M3 — Extraction** | file walk, tree-sitter for 5 languages, resolution pass, confidence | new |
+| **M4 — Query engine** | FTS index, explore/callers/callees/impact/path/context | new |
+| **M5 — CLI + sync** | binary, JSON output, incremental sync, compaction | new |
+| **M6 — Bindings** | Bun/Node FFI, C-compatible surface | #3 |
+| **v1 — Enrichment** | agent detection, `LlmProvider`, concept nodes, summaries | new |
+| **v1 — Vectors** | fastembed/ONNX embeddings, ANN index, hybrid ranking | #10–#13, #16 (deferred) |
+
+### 7.1 Dependency changes
+
+`rust-bert` is removed. It pulls `torch-sys`, whose build script downloads
+libtorch — a multi-gigabyte native dependency that **currently fails to build,
+leaving CI red on `main`**. It also makes a single portable binary impossible,
+which contradicts the project's core portability goal. When vectors land in v1,
+the replacement is `fastembed`/ONNX Runtime or Candle, both of which link
+statically.
+
+`hnsw` is removed alongside it and returns with v1 vectors.
+
+### 7.2 Success criteria
+
+The v0.2.0 criteria measured an e-commerce OLTP workload and no longer describe
+anything cndb does. Replacements, measured against real open-source repositories
+rather than synthetic data:
+
+| # | Criterion | Target |
+|---|---|---|
+| C1 | Cold index, 10k-file repo | < 60 s |
+| C2 | Incremental sync, one changed file | < 200 ms |
+| C3 | Cold start (open + load index) | < 200 ms |
+| C4 | `callers` / `callees` | < 5 ms |
+| C5 | `impact`, depth 3 | < 50 ms |
+| C6 | `explore` end to end, with snippets | < 100 ms |
+| C7 | Graph file size | < 20% of repo source size |
+| C8 | Crash during commit | previous generation always recoverable |
+| C9 | Portability | graph file copies across macOS/Linux/Windows |
+
+C8 and C9 carry over from v0.2.0 (issues #22, #14) essentially unchanged — they
+were always about the storage engine, and the storage engine survived the pivot.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.3.0
 **Status:** Draft
-**Supersedes:** the v0.2.0 technical design in issue #1
+**Supersedes:** the v0.2.0 technical design (issue #1) and the PoC plan (issue #2)
 
 ---
 
@@ -20,33 +20,110 @@ cndb is a storage engine in its own right. It is an alternative to SQLite, not
 a layer on top of one. There is no server, no daemon, no network protocol, and
 no third-party database underneath it.
 
-### 1.1 What changed from v0.2.0
+### 1.1 Lineage
 
-v0.2.0 described a hybrid **document + vector** database validated against an
-e-commerce workload (order history, 10M synthetic orders, concurrent HTTP load).
-v0.3.0 keeps the storage thesis and replaces the data model and the workload.
+Two prior documents define the project. They do not agree with each other, and
+the difference between them matters.
 
-| | v0.2.0 | v0.3.0 |
+**Issue #1 — TDD v0.2.0.** The founding document. Its mission is *"a
+high-performance, self-contained, single-file vector database... the power of
+**contextual semantic search** with the simplicity and portability of a custom,
+SQLite-inspired file format."* Four components: Driver/API, Embedding Engine,
+Vector Index, Custom Storage. A four-method API — `connect`, `add`, `search`,
+`save`. Future work: compaction, single-writer/multi-reader concurrency, and
+C-compatible FFI bindings.
+
+**Issue #2 — PoC.** Reframes cndb as *"a hybrid **NoSQL document + vector**
+database."* This is a scope expansion rather than a restatement: it adds
+collections, full CRUD, `find_where`, aggregations, and hybrid filter+vector
+queries. It then selects an **e-commerce workload** — 10M synthetic orders,
+`OrderHistory`, 100 concurrent JMeter threads — and makes hitting its latency
+targets a binary pass/fail gate on the whole project.
+
+v0.3.0 aligns with issue #1 and steps back from issue #2.
+
+Nothing in the founding document points at e-commerce. Its stated purpose is
+*contextual* retrieval; the repository is named ContextDB; its original README
+described *"contextual data, relevant for your CLI shell."* The intent was
+always context retrieval for a local CLI and LLM workflow. Issue #2 chose an
+e-commerce benchmark to have something measurable and, in doing so, pulled the
+project toward being a general-purpose document store competing with MongoDB.
+
+Indexing a codebase into a queryable graph is a direct expression of issue #1's
+mission. The pivot is a return to it, not a departure from it.
+
+Issue #2's own risk register rated R-05, *"3 weeks insufficient for build,"* at
+**Very High** probability. That risk materialised: ten months after these issues
+were filed, `src/` contained empty stub structs and no PoC had run. The scope
+that could not be built in three weeks was #2's, not #1's.
+
+### 1.2 What carries forward, and what does not
+
+Carried forward from issue #1, unchanged:
+
+- Everything in one `.cndb` file you can copy between machines
+- Local-first, in-process, zero runtime dependencies, no server
+- Append-only log with an atomically committed master index block
+- Custom binary format, no external database underneath
+- A single index pointer to one master block holding every index
+  (issue #2 split this into separate document and vector pointers; #1's
+  single-block design is simpler and is what §3 specifies)
+- C-compatible FFI bindings as a first-class goal, not an afterthought (§6.1)
+- Compaction and single-writer/multi-reader concurrency as known future work
+
+Changed:
+
+| | Prior | v0.3.0 |
 |---|---|---|
-| Primary model | BSON documents | Graph of nodes + edges (stored as documents) |
+| Primary model | BSON documents | Graph of nodes + edges, stored as documents |
 | Primary retrieval | Vector similarity (HNSW) | Graph traversal + full-text |
 | Target workload | E-commerce OLTP, 100 concurrent users | Code intelligence, single local process |
 | Primary consumer | Application code | Coding agents and application code |
-| Vectors | Core, day one | Deferred to v1, behind a feature flag |
+| Record framing | `[len][BSON]` (#1), `[len][collection][BSON]` (#2) | `[len][kind][crc][BSON]` (§3.1) |
+| Header | 16 bytes (#1) / 32 bytes (#2), overwritten in place | 2 × 64-byte slots, ping-pong commit (§3.2) |
 
-Unchanged, and still the point of the project:
+Dropped from issue #2, as scope that served the e-commerce framing:
 
-- Everything in one `.cndb` file you can copy between machines
-- Local-first, in-process, zero runtime dependencies
-- Append-only log with an atomically committed index block
-- Custom binary format, no external database
+- Aggregations (FR-D-06) — `stats` is counting over indexes, not a query engine
+- Concurrent-user latency targets — there is one local process, not 100 users
+- Synthetic 10M-document ingest-rate goals — replaced by §7.2, measured on real
+  repositories
 
-### 1.2 Non-goals for v0
+### 1.3 On deferring vectors
+
+Semantic search is issue #1's stated mission, and deferring it is the largest
+divergence in this document. It is a deferral, not a deletion, and the reasoning
+should be explicit.
+
+Graph traversal answers `callers`, `callees`, `impact` and `path` exactly and
+without embeddings. It is `explore` that suffers: BM25 over identifiers matches
+the literal token `auth`, but a query like *"how do users sign in"* will not
+lexically reach `verify_credentials`. That is the query shape agents actually
+issue, and it is what issue #1 meant by contextual retrieval.
+
+Against that: in code, identifiers are unusually information-dense, so
+lexical ranking over names, signatures and doc comments is stronger than it
+would be over prose. Both comparable projects ship without vectors — CodeGraph
+on SQLite FTS5, Graphify explicitly choosing *"a real graph"* over embeddings.
+Exact structure is the harder half to build and the half that must be correct
+first.
+
+So vectors are v1's first item rather than a possibility, and the format
+reserves room for them now: `MasterIndex` gains an ANN index as another field,
+the record `kind` byte has 252 unused values, and the header keeps 24 reserved
+bytes. No format break is required to add them.
+
+The v1 embedding backend links statically (`fastembed`/ONNX or Candle) and
+embeds symbol signatures and doc comments only — never whole files. `rust-bert`
+is not that backend; see §7.1.
+
+### 1.4 Non-goals for v0
 
 - Distributed or networked operation
 - Multi-writer concurrency (single writer, multiple readers)
-- Vector search and embeddings (v1)
+- Vector search and embeddings (v1 — see §1.3)
 - LLM-driven extraction (v1 — see §5.4)
+- Aggregation and general-purpose query language
 - MCP server (deliberately never — see §6)
 
 ---
@@ -181,6 +258,13 @@ The log is append-only, so updates and deletes are tombstones. `sync` on a
 changed file tombstones everything in `by_file[file_id]` and appends fresh
 records. When `dead.len() / total` crosses a threshold (default 0.3), compaction
 rewrites live records into a sibling file and renames it into place.
+
+Issue #1 listed compaction as future work, which was reasonable for a
+write-mostly-once vector store. The pivot promotes it into v0: a code graph is
+re-synced on every file save, so a working session churns tombstones
+continuously and an un-compacted file would grow without bound during normal
+use. This is the one place where the change of workload makes the storage
+engine's job harder rather than easier.
 
 ---
 
@@ -379,8 +463,12 @@ cndb stats
 | **M4 — Query engine** | FTS index, explore/callers/callees/impact/path/context | new |
 | **M5 — CLI + sync** | binary, JSON output, incremental sync, compaction | new |
 | **M6 — Bindings** | Bun/Node FFI, C-compatible surface | #3 |
-| **v1 — Enrichment** | agent detection, `LlmProvider`, concept nodes, summaries | new |
-| **v1 — Vectors** | fastembed/ONNX embeddings, ANN index, hybrid ranking | #10–#13, #16 (deferred) |
+| **v1.1 — Vectors** | statically linked embeddings, ANN index, hybrid ranking on `explore` | #10–#13, #16 (deferred) |
+| **v1.2 — Enrichment** | agent detection, `LlmProvider`, concept nodes, summaries | new |
+
+Vectors lead v1 rather than trailing it: semantic retrieval is issue #1's
+founding mission, and §1.3 records why it is deferred out of v0 rather than
+abandoned.
 
 ### 7.1 Dependency changes
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,157 @@
-// API module for cndb
+//! The public database handle.
+//!
+//! M1 exposes documents. M2 layers the graph model over this — `insert_node`,
+//! `insert_edge`, `neighbors` — reusing the same engine and commit protocol.
 
-pub struct Api {
-    // API implementation will go here
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::document::codec::{from_bson_bytes, to_bson_bytes};
+use crate::error::Result;
+use crate::storage::{DocId, RecordKind, Stats, StorageEngine};
+
+/// An open cndb database.
+///
+/// Writes are buffered until [`commit`](Self::commit); a handle dropped without
+/// committing discards them, which is what makes an interrupted run leave the
+/// file at its last consistent state rather than half-updated.
+///
+/// ```
+/// # fn main() -> cndb::Result<()> {
+/// # let dir = tempfile::TempDir::new().unwrap();
+/// # let path = dir.path().join("graph.cndb");
+/// use serde_json::json;
+///
+/// let mut db = cndb::Cndb::open(&path)?;
+/// let id = db.insert(&json!({ "name": "parse_header" }))?;
+/// db.commit()?;
+///
+/// assert_eq!(db.get(id)?["name"], "parse_header");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct Cndb {
+    store: StorageEngine,
+}
+
+impl Cndb {
+    /// Open `path`, creating an empty database if it does not exist.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Ok(Cndb {
+            store: StorageEngine::open(path)?,
+        })
+    }
+
+    /// Store a JSON object and return its id.
+    ///
+    /// Errors if `doc` is not an object. Durable after [`commit`](Self::commit).
+    pub fn insert(&mut self, doc: &Value) -> Result<DocId> {
+        let bytes = to_bson_bytes(doc)?;
+        self.store.append(RecordKind::Blob, &bytes)
+    }
+
+    /// Fetch a document by id.
+    pub fn get(&self, id: DocId) -> Result<Value> {
+        from_bson_bytes(&self.store.read(id)?)
+    }
+
+    /// Delete a document.
+    pub fn delete(&mut self, id: DocId) -> Result<()> {
+        self.store.tombstone(id)
+    }
+
+    /// Make every write since the last commit durable.
+    pub fn commit(&mut self) -> Result<()> {
+        self.store.commit()
+    }
+
+    /// Check every committed record's checksum, returning how many were read.
+    pub fn verify(&self) -> Result<usize> {
+        self.store.verify()
+    }
+
+    /// Number of live documents.
+    pub fn len(&self) -> usize {
+        self.store.len()
+    }
+
+    /// True when no live documents remain.
+    pub fn is_empty(&self) -> bool {
+        self.store.is_empty()
+    }
+
+    /// Every live document id, in no particular order.
+    pub fn ids(&self) -> impl Iterator<Item = DocId> + '_ {
+        self.store.live_ids()
+    }
+
+    /// A snapshot of engine state.
+    pub fn stats(&self) -> Stats {
+        self.store.stats()
+    }
+
+    /// The underlying storage engine.
+    pub fn store(&self) -> &StorageEngine {
+        &self.store
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::CndbError;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    #[test]
+    fn documents_roundtrip_across_a_reopen() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.cndb");
+
+        let (kept, removed) = {
+            let mut db = Cndb::open(&path).unwrap();
+            let kept = db
+                .insert(&json!({ "kind": "Function", "name": "commit" }))
+                .unwrap();
+            let removed = db
+                .insert(&json!({ "kind": "Function", "name": "gone" }))
+                .unwrap();
+            db.delete(removed).unwrap();
+            db.commit().unwrap();
+            (kept, removed)
+        };
+
+        let db = Cndb::open(&path).unwrap();
+        assert_eq!(db.len(), 1);
+        assert_eq!(db.get(kept).unwrap()["name"], "commit");
+        assert!(matches!(db.get(removed), Err(CndbError::Deleted(_))));
+        assert_eq!(db.ids().collect::<Vec<_>>(), vec![kept]);
+        db.verify().unwrap();
+    }
+
+    #[test]
+    fn dropping_without_committing_discards_writes() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.cndb");
+        {
+            let mut db = Cndb::open(&path).unwrap();
+            db.insert(&json!({ "name": "never committed" })).unwrap();
+        }
+        assert!(Cndb::open(&path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn non_objects_are_refused_before_anything_is_written() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("api.cndb");
+        let mut db = Cndb::open(&path).unwrap();
+
+        assert!(matches!(
+            db.insert(&json!([1, 2, 3])),
+            Err(CndbError::NotAnObject { .. })
+        ));
+        assert!(db.is_empty(), "a rejected insert must not consume an id");
+    }
 }

--- a/src/document/codec.rs
+++ b/src/document/codec.rs
@@ -1,0 +1,144 @@
+//! JSON to BSON document encoding (issue #8).
+//!
+//! BSON is the payload format for stored documents. It preserves types that a
+//! text encoding would flatten, and it is what issues #1 and #2 both specified.
+//!
+//! Only JSON objects are storable. BSON's top-level type *is* a document, so a
+//! bare scalar or array has no representation; rejecting those here beats
+//! silently wrapping them in a synthetic field the caller never asked for.
+
+use serde_json::Value;
+
+use crate::error::{CndbError, Result};
+
+/// Encode a JSON object as BSON bytes.
+pub fn to_bson_bytes(value: &Value) -> Result<Vec<u8>> {
+    if !value.is_object() {
+        return Err(CndbError::NotAnObject {
+            found: type_name(value),
+        });
+    }
+    let doc = bson::to_document(value).map_err(|e| CndbError::Bson(e.to_string()))?;
+    let mut out = Vec::new();
+    doc.to_writer(&mut out)
+        .map_err(|e| CndbError::Bson(e.to_string()))?;
+    Ok(out)
+}
+
+/// Decode BSON bytes back into a JSON object.
+pub fn from_bson_bytes(bytes: &[u8]) -> Result<Value> {
+    let doc: bson::Document =
+        bson::from_slice(bytes).map_err(|e| CndbError::Bson(e.to_string()))?;
+    bson::from_document(doc).map_err(|e| CndbError::Bson(e.to_string()))
+}
+
+/// The JSON type name, for error messages.
+fn type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn roundtrip(value: Value) -> Value {
+        from_bson_bytes(&to_bson_bytes(&value).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn flat_objects_roundtrip() {
+        let doc = json!({ "name": "parse_header", "line": 42, "public": true });
+        assert_eq!(roundtrip(doc.clone()), doc);
+    }
+
+    #[test]
+    fn nested_objects_and_arrays_roundtrip() {
+        // Shaped like the graph nodes M2 will store.
+        let doc = json!({
+            "kind": "Function",
+            "qualified_name": "cndb::storage::engine::StorageEngine::commit",
+            "span": { "start_line": 231, "end_line": 268, "start_byte": 7104 },
+            "params": [
+                { "name": "self", "by_ref": true },
+                { "name": "force", "by_ref": false }
+            ],
+            "doc": null,
+            "tags": ["storage", "commit", "durability"]
+        });
+        assert_eq!(roundtrip(doc.clone()), doc);
+    }
+
+    #[test]
+    fn scalar_types_keep_their_identity() {
+        let doc = json!({
+            "null": null,
+            "true": true,
+            "false": false,
+            "int": 42,
+            "negative": -7,
+            "zero": 0,
+            "float": 1.5,
+            "string": "",
+            "unicode": "λ → ∀ 日本語",
+            "empty_object": {},
+            "empty_array": [],
+        });
+        let out = roundtrip(doc.clone());
+        assert_eq!(out, doc);
+        assert!(out["null"].is_null());
+        assert_eq!(out["int"], json!(42));
+        assert_eq!(out["float"], json!(1.5));
+    }
+
+    #[test]
+    fn integers_do_not_silently_become_floats() {
+        let out = roundtrip(json!({ "n": 9_007_199_254_740_993i64 }));
+        assert_eq!(out["n"], json!(9_007_199_254_740_993i64));
+        assert!(out["n"].is_i64(), "large integers must stay integral");
+    }
+
+    #[test]
+    fn deep_nesting_roundtrips() {
+        let mut doc = json!({ "leaf": true });
+        for i in 0..32 {
+            doc = json!({ "depth": i, "child": doc });
+        }
+        assert_eq!(roundtrip(doc.clone()), doc);
+    }
+
+    #[test]
+    fn non_objects_are_refused_with_their_type_named() {
+        for (value, expected) in [
+            (json!(null), "null"),
+            (json!(true), "a boolean"),
+            (json!(3), "a number"),
+            (json!("text"), "a string"),
+            (json!([1, 2, 3]), "an array"),
+        ] {
+            match to_bson_bytes(&value) {
+                Err(CndbError::NotAnObject { found }) => assert_eq!(found, expected),
+                other => panic!("expected {value} to be refused, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn garbage_bytes_do_not_decode() {
+        assert!(from_bson_bytes(b"not bson at all").is_err());
+        assert!(from_bson_bytes(&[]).is_err());
+    }
+
+    #[test]
+    fn a_truncated_document_does_not_decode() {
+        let bytes = to_bson_bytes(&json!({ "key": "a value long enough to cut" })).unwrap();
+        assert!(from_bson_bytes(&bytes[..bytes.len() - 5]).is_err());
+    }
+}

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -3,4 +3,3 @@
 pub mod query;
 
 pub use query::*;
-

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -1,5 +1,7 @@
-// Document module for cndb
+//! Document encoding.
+//!
+//! M2 adds the graph model — typed nodes and edges — on top of this.
 
-pub mod query;
+pub mod codec;
 
-pub use query::*;
+pub use codec::{from_bson_bytes, to_bson_bytes};

--- a/src/document/query.rs
+++ b/src/document/query.rs
@@ -3,4 +3,3 @@
 pub struct Query {
     // Query implementation will go here
 }
-

--- a/src/document/query.rs
+++ b/src/document/query.rs
@@ -1,5 +1,0 @@
-// Query functionality for cndb documents
-
-pub struct Query {
-    // Query implementation will go here
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,52 @@
+//! Error types for cndb.
+
+use crate::storage::DocId;
+
+/// Result alias used throughout cndb.
+pub type Result<T> = std::result::Result<T, CndbError>;
+
+/// Every way a cndb operation can fail.
+#[derive(Debug, thiserror::Error)]
+pub enum CndbError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("not a cndb file: expected magic {expected:?}, found {found:?}")]
+    BadMagic { expected: [u8; 4], found: [u8; 4] },
+
+    #[error("unsupported format version {found:#010x}; this build supports {supported:#010x}")]
+    UnsupportedVersion { found: u32, supported: u32 },
+
+    #[error("no valid header: both slots are corrupt or this is not a cndb database")]
+    NoValidHeader,
+
+    #[error("header slot {slot} failed its checksum")]
+    HeaderChecksum { slot: usize },
+
+    #[error("record at offset {offset} failed its checksum")]
+    RecordChecksum { offset: u64 },
+
+    #[error("record at offset {offset} declares {len} bytes, over the {max} byte limit")]
+    RecordTooLarge { offset: u64, len: u64, max: u64 },
+
+    #[error("unknown record kind {kind} at offset {offset}")]
+    UnknownRecordKind { kind: u8, offset: u64 },
+
+    #[error("unexpected end of file at offset {offset}: needed {needed} bytes")]
+    UnexpectedEof { offset: u64, needed: u64 },
+
+    #[error("document {0} not found")]
+    NotFound(DocId),
+
+    #[error("document {0} was deleted")]
+    Deleted(DocId),
+
+    #[error("bson: {0}")]
+    Bson(String),
+
+    #[error("only JSON objects can be stored as documents, found {found}")]
+    NotAnObject { found: &'static str },
+
+    #[error("master index is corrupt: {0}")]
+    CorruptIndex(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,38 @@
-// cndb - ContextDB
-// Single file database optimized for storing and retrieving contextual data
+//! # cndb — ContextDB
+//!
+//! A single-file, embedded graph knowledge base for codebases.
+//!
+//! cndb is a storage engine in its own right, not a layer over another
+//! database. Everything lives in one portable `.cndb` file: an append-only
+//! record log plus a master index committed atomically via two alternating
+//! header slots. See `docs/ARCHITECTURE.md` for the full design.
+//!
+//! ## Status
+//!
+//! M1 — the storage core — is implemented: file format, record log, document
+//! offset map, BSON codec, and crash-safe commit and recovery. The graph model,
+//! extraction and query engines follow in M2 through M5.
+//!
+//! ```
+//! # fn main() -> cndb::Result<()> {
+//! # let dir = tempfile::TempDir::new().unwrap();
+//! # let path = dir.path().join("graph.cndb");
+//! use serde_json::json;
+//!
+//! let mut db = cndb::Cndb::open(&path)?;
+//! let id = db.insert(&json!({ "kind": "Function", "name": "parse_header" }))?;
+//! db.commit()?;
+//! assert_eq!(db.get(id)?["kind"], "Function");
+//! # Ok(())
+//! # }
+//! ```
 
 pub mod api;
 pub mod document;
+pub mod error;
 pub mod storage;
-pub mod vector;
 
-// Re-export main modules for easier access
-pub use api::*;
-pub use document::*;
-pub use storage::*;
-pub use vector::*;
+pub use api::Cndb;
+pub use document::{from_bson_bytes, to_bson_bytes};
+pub use error::{CndbError, Result};
+pub use storage::{DocId, MasterIndex, Record, RecordKind, Stats, StorageEngine, FORMAT_VERSION};

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -3,4 +3,3 @@
 pub struct StorageEngine {
     // Storage engine implementation will go here
 }
-

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1,5 +1,777 @@
-// Storage engine implementation for cndb
+//! The append-only storage engine.
+//!
+//! # Commit protocol
+//!
+//! A commit never overwrites a byte the live generation depends on:
+//!
+//! 1. Records are appended at `log_end` and the payload is flushed.
+//! 2. The master index is appended *as an ordinary record*, then flushed.
+//! 3. A header with `generation + 1` is written to the older slot and flushed.
+//!
+//! Step 3 is the commit point. A crash before it leaves the previous header
+//! untouched, still pointing at the previous master index, with every new byte
+//! sitting beyond the old `log_end` where the next append overwrites it. A
+//! crash *during* it tears at most one header slot, and the other survives.
+//!
+//! Writing the master index into the log rather than into reserved space is
+//! what makes this work. Appends always start past the live master record, so
+//! it stays readable until its successor is committed, and scans skip it by
+//! kind. Superseded master records become dead space that compaction reclaims
+//! (M5). This is also why issue #14's optional write-ahead log is absent: the
+//! ordering above already makes a commit atomic.
 
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use crate::error::{CndbError, Result};
+use crate::storage::header::{self, Header, HEADER_SIZE, HEADER_SLOTS, LOG_START};
+use crate::storage::index::MasterIndex;
+use crate::storage::pos_io::{read_exact_at, write_all_at};
+use crate::storage::record::{
+    decode_frame, encode_frame, verify_payload, DocId, Frame, Record, RecordKind, MAX_RECORD_LEN,
+    RECORD_HEADER_SIZE,
+};
+
+/// A single `.cndb` file, opened for reading and writing.
+///
+/// One writer at a time. Reads take `&self` and use positioned I/O, so the
+/// multiple-reader half of the roadmap's concurrency model needs no API change.
+#[derive(Debug)]
 pub struct StorageEngine {
-    // Storage engine implementation will go here
+    file: File,
+    path: PathBuf,
+    /// The live header, i.e. the last committed state.
+    header: Header,
+    /// Both decoded slots, so a commit can pick the one safe to overwrite.
+    slots: [Option<Header>; HEADER_SLOTS],
+    /// Which slot `header` came from.
+    live_slot: usize,
+    index: MasterIndex,
+    /// First free byte. Runs ahead of `header.log_end` between commits.
+    end: u64,
+    /// Whether anything has been appended since the last commit.
+    dirty: bool,
+}
+
+/// A snapshot of engine state, for diagnostics and tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Stats {
+    pub generation: u64,
+    pub live_docs: usize,
+    pub dead_docs: usize,
+    pub committed_len: u64,
+    pub pending_len: u64,
+}
+
+impl StorageEngine {
+    /// Open `path`, creating an empty database if it does not exist.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)?;
+
+        let file_len = file.metadata()?.len();
+        if file_len > 0 {
+            return Self::load(file, path, file_len);
+        }
+
+        let mut engine = StorageEngine {
+            file,
+            path,
+            header: Header::initial(),
+            slots: [None, None],
+            live_slot: 0,
+            index: MasterIndex::default(),
+            end: LOG_START,
+            dirty: false,
+        };
+        engine.initialize()?;
+        Ok(engine)
+    }
+
+    /// Lay down the header region of a brand-new database.
+    fn initialize(&mut self) -> Result<()> {
+        let mut region = [0u8; HEADER_SIZE * HEADER_SLOTS];
+        // Slot 0 holds generation 0; slot 1 stays zeroed and so decodes as
+        // invalid, which makes it the first commit's victim.
+        region[..HEADER_SIZE].copy_from_slice(&self.header.encode());
+        write_all_at(&self.file, &region, 0)?;
+        self.file.sync_all()?;
+        self.slots = [Some(self.header), None];
+        self.live_slot = 0;
+        Ok(())
+    }
+
+    /// Recover an existing database from its headers.
+    fn load(file: File, path: PathBuf, file_len: u64) -> Result<Self> {
+        if file_len < LOG_START {
+            return Err(CndbError::UnexpectedEof {
+                offset: 0,
+                needed: LOG_START,
+            });
+        }
+
+        let mut region = [0u8; HEADER_SIZE * HEADER_SLOTS];
+        read_exact_at(&file, &mut region, 0)?;
+
+        let mut slots: [Option<Header>; HEADER_SLOTS] = [None; HEADER_SLOTS];
+        let mut first_error = None;
+        for (slot, out) in slots.iter_mut().enumerate() {
+            let bytes: [u8; HEADER_SIZE] = region[slot * HEADER_SIZE..(slot + 1) * HEADER_SIZE]
+                .try_into()
+                .expect("slot sized");
+            match Header::decode(&bytes, slot) {
+                Ok(h) => *out = Some(h),
+                Err(e) => {
+                    first_error.get_or_insert(e);
+                }
+            }
+        }
+
+        // When both slots fail, report why the first one did: "wrong magic" or
+        // "unsupported version" is far more useful than "no valid header".
+        let (header, live_slot) =
+            header::select_live(&slots).map_err(|fallback| first_error.unwrap_or(fallback))?;
+
+        if header.log_end > file_len {
+            return Err(CndbError::UnexpectedEof {
+                offset: file_len,
+                needed: header.log_end,
+            });
+        }
+
+        let index = if header.master_len == 0 {
+            MasterIndex::default()
+        } else {
+            let record = read_record_at(&file, header.master_ptr)?;
+            if record.kind != RecordKind::MasterIndex {
+                return Err(CndbError::CorruptIndex(format!(
+                    "record at {} is {:?}, not a master index",
+                    header.master_ptr, record.kind
+                )));
+            }
+            MasterIndex::decode(&record.payload)?
+        };
+
+        Ok(StorageEngine {
+            file,
+            path,
+            header,
+            slots,
+            live_slot,
+            index,
+            end: header.log_end,
+            dirty: false,
+        })
+    }
+
+    /// Append a document and return its id.
+    ///
+    /// Durable only after [`commit`](Self::commit).
+    pub fn append(&mut self, kind: RecordKind, payload: &[u8]) -> Result<DocId> {
+        let offset = self.append_raw(kind, payload)?;
+        let id = self.index.allocate_id();
+        self.index.insert(id, offset);
+        Ok(id)
+    }
+
+    /// Append a framed record and return where it landed, leaving the index
+    /// alone. Used for documents and for the master index itself.
+    fn append_raw(&mut self, kind: RecordKind, payload: &[u8]) -> Result<u64> {
+        let len = payload.len() as u64;
+        if len > MAX_RECORD_LEN {
+            return Err(CndbError::RecordTooLarge {
+                offset: self.end,
+                len,
+                max: MAX_RECORD_LEN,
+            });
+        }
+
+        let offset = self.end;
+        write_all_at(&self.file, &encode_frame(kind, payload), offset)?;
+        write_all_at(&self.file, payload, offset + RECORD_HEADER_SIZE)?;
+        self.end = offset + RECORD_HEADER_SIZE + len;
+        self.dirty = true;
+        Ok(offset)
+    }
+
+    /// Read a document's payload.
+    pub fn read(&self, id: DocId) -> Result<Vec<u8>> {
+        Ok(self.read_record(id)?.payload)
+    }
+
+    /// Read a document with its record kind.
+    pub fn read_record(&self, id: DocId) -> Result<Record> {
+        if self.index.dead.contains(&id) {
+            return Err(CndbError::Deleted(id));
+        }
+        let offset = self
+            .index
+            .offsets
+            .get(&id)
+            .copied()
+            .ok_or(CndbError::NotFound(id))?;
+        read_record_at(&self.file, offset)
+    }
+
+    /// Mark a document deleted.
+    ///
+    /// Appends a tombstone so the deletion is itself recoverable, then hides
+    /// the document. The original record stays on disk until compaction.
+    pub fn tombstone(&mut self, id: DocId) -> Result<()> {
+        if self.index.dead.contains(&id) {
+            return Err(CndbError::Deleted(id));
+        }
+        if !self.index.offsets.contains_key(&id) {
+            return Err(CndbError::NotFound(id));
+        }
+        self.append_raw(RecordKind::Tombstone, &id.0.to_le_bytes())?;
+        self.index.dead.insert(id);
+        Ok(())
+    }
+
+    /// Make every append since the last commit durable.
+    ///
+    /// A no-op when nothing has changed.
+    pub fn commit(&mut self) -> Result<()> {
+        if !self.dirty {
+            return Ok(());
+        }
+
+        // 1. Records reach disk before anything points at them.
+        self.file.sync_data()?;
+
+        // 2. The master index goes into the log like any other record.
+        let payload = self.index.encode()?;
+        let master_ptr = self.append_raw(RecordKind::MasterIndex, &payload)?;
+        self.file.sync_data()?;
+
+        // 3. The commit point.
+        let next = Header {
+            generation: self.header.generation + 1,
+            master_ptr,
+            master_len: payload.len() as u64,
+            log_end: self.end,
+        };
+        let slot = header::victim_slot(&self.slots);
+        debug_assert_ne!(slot, self.live_slot, "commit would clobber the live header");
+        write_all_at(&self.file, &next.encode(), Header::slot_offset(slot))?;
+        self.file.sync_data()?;
+
+        self.header = next;
+        self.slots[slot] = Some(next);
+        self.live_slot = slot;
+        self.dirty = false;
+        Ok(())
+    }
+
+    /// Walk every record from the start of the log, checking all checksums.
+    ///
+    /// Returns how many records were read. Only committed bytes are scanned.
+    pub fn verify(&self) -> Result<usize> {
+        let mut offset = LOG_START;
+        let mut count = 0;
+        while offset < self.header.log_end {
+            let frame = read_frame_at(&self.file, offset)?;
+            let mut payload = vec![0u8; frame.len as usize];
+            read_exact_at(&self.file, &mut payload, offset + RECORD_HEADER_SIZE)?;
+            verify_payload(&frame, &payload, offset)?;
+            offset += frame.total_len();
+            count += 1;
+        }
+        if offset != self.header.log_end {
+            return Err(CndbError::CorruptIndex(format!(
+                "log ends at {offset}, header says {}",
+                self.header.log_end
+            )));
+        }
+        Ok(count)
+    }
+
+    /// The committed generation. Increments on every commit that does work.
+    pub fn generation(&self) -> u64 {
+        self.header.generation
+    }
+
+    /// Which header slot currently holds the live generation.
+    pub fn live_slot(&self) -> usize {
+        self.live_slot
+    }
+
+    /// True when appends are waiting for a commit.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Path this database was opened from.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Read-only view of the master index.
+    pub fn index(&self) -> &MasterIndex {
+        &self.index
+    }
+
+    /// Number of live documents.
+    pub fn len(&self) -> usize {
+        self.index.live_count()
+    }
+
+    /// True when no live documents remain.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Every live document id, in no particular order.
+    pub fn live_ids(&self) -> impl Iterator<Item = DocId> + '_ {
+        self.index.live_ids()
+    }
+
+    /// A snapshot of engine state.
+    pub fn stats(&self) -> Stats {
+        Stats {
+            generation: self.header.generation,
+            live_docs: self.index.live_count(),
+            dead_docs: self.index.dead_count(),
+            committed_len: self.header.log_end,
+            pending_len: self.end,
+        }
+    }
+}
+
+/// Read and validate a record frame at `offset`.
+fn read_frame_at(file: &File, offset: u64) -> Result<Frame> {
+    let mut buf = [0u8; RECORD_HEADER_SIZE as usize];
+    read_exact_at(file, &mut buf, offset)?;
+    decode_frame(&buf, offset)
+}
+
+/// Read a whole record at `offset`, verifying its checksum.
+fn read_record_at(file: &File, offset: u64) -> Result<Record> {
+    let frame = read_frame_at(file, offset)?;
+    let mut payload = vec![0u8; frame.len as usize];
+    read_exact_at(file, &mut payload, offset + RECORD_HEADER_SIZE)?;
+    verify_payload(&frame, &payload, offset)?;
+    Ok(Record {
+        kind: frame.kind,
+        payload,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn scratch() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.cndb");
+        (dir, path)
+    }
+
+    fn blob(engine: &mut StorageEngine, body: &str) -> DocId {
+        engine.append(RecordKind::Blob, body.as_bytes()).unwrap()
+    }
+
+    /// Overwrite bytes on disk behind the engine's back, to simulate damage.
+    fn damage(path: &Path, offset: u64, bytes: &[u8]) {
+        let file = OpenOptions::new().write(true).open(path).unwrap();
+        write_all_at(&file, bytes, offset).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    #[test]
+    fn a_new_database_starts_empty_and_valid() {
+        let (_dir, path) = scratch();
+        let engine = StorageEngine::open(&path).unwrap();
+
+        assert_eq!(engine.generation(), 0);
+        assert!(engine.is_empty());
+        assert!(!engine.is_dirty());
+        assert_eq!(engine.verify().unwrap(), 0);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), LOG_START);
+    }
+
+    #[test]
+    fn appends_are_readable_before_they_are_committed() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+
+        let id = blob(&mut engine, "hello");
+        assert!(engine.is_dirty());
+        assert_eq!(engine.read(id).unwrap(), b"hello");
+        assert_eq!(engine.len(), 1);
+    }
+
+    #[test]
+    fn ids_are_unique_and_documents_do_not_collide() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+
+        let ids: Vec<_> = (0..64)
+            .map(|i| blob(&mut engine, &format!("doc-{i}")))
+            .collect();
+        engine.commit().unwrap();
+
+        let unique: std::collections::HashSet<_> = ids.iter().collect();
+        assert_eq!(unique.len(), ids.len());
+        for (i, id) in ids.iter().enumerate() {
+            assert_eq!(engine.read(*id).unwrap(), format!("doc-{i}").as_bytes());
+        }
+    }
+
+    #[test]
+    fn data_survives_a_reopen() {
+        let (_dir, path) = scratch();
+        let id = {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            let id = blob(&mut engine, "durable");
+            engine.commit().unwrap();
+            id
+        };
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.generation(), 1);
+        assert_eq!(engine.read(id).unwrap(), b"durable");
+        assert_eq!(engine.len(), 1);
+    }
+
+    #[test]
+    fn uncommitted_appends_are_lost_on_reopen() {
+        let (_dir, path) = scratch();
+        let (kept, dropped) = {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            let kept = blob(&mut engine, "committed");
+            engine.commit().unwrap();
+            // Simulates a crash: written and flushed, but never committed.
+            let dropped = blob(&mut engine, "in flight");
+            (kept, dropped)
+        };
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.read(kept).unwrap(), b"committed");
+        assert!(matches!(engine.read(dropped), Err(CndbError::NotFound(_))));
+        assert_eq!(engine.len(), 1);
+    }
+
+    #[test]
+    fn an_uncommitted_append_is_overwritten_not_orphaned() {
+        let (_dir, path) = scratch();
+        {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            blob(&mut engine, "committed");
+            engine.commit().unwrap();
+            blob(&mut engine, "this text must not survive");
+        }
+
+        let mut engine = StorageEngine::open(&path).unwrap();
+        let replacement = blob(&mut engine, "second");
+        engine.commit().unwrap();
+
+        // The lost record's space was reused, and the log still scans clean.
+        assert_eq!(engine.read(replacement).unwrap(), b"second");
+        engine.verify().unwrap();
+    }
+
+    #[test]
+    fn ids_do_not_restart_after_a_reopen() {
+        let (_dir, path) = scratch();
+        let first = {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            let id = blob(&mut engine, "a");
+            engine.commit().unwrap();
+            id
+        };
+
+        let mut engine = StorageEngine::open(&path).unwrap();
+        let second = blob(&mut engine, "b");
+        assert!(second > first, "{second} should follow {first}");
+        assert_eq!(engine.read(first).unwrap(), b"a");
+    }
+
+    #[test]
+    fn commits_alternate_header_slots() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.live_slot(), 0, "generation 0 is written to slot 0");
+
+        let mut seen = Vec::new();
+        for i in 0..6 {
+            blob(&mut engine, &format!("v{i}"));
+            engine.commit().unwrap();
+            seen.push(engine.live_slot());
+            assert_eq!(engine.generation(), i + 1);
+        }
+        assert_eq!(seen, vec![1, 0, 1, 0, 1, 0]);
+    }
+
+    #[test]
+    fn committing_nothing_does_nothing() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+        blob(&mut engine, "x");
+        engine.commit().unwrap();
+
+        let before = engine.stats();
+        engine.commit().unwrap();
+        engine.commit().unwrap();
+        assert_eq!(
+            engine.stats(),
+            before,
+            "an empty commit must not burn a generation"
+        );
+    }
+
+    #[test]
+    fn a_torn_header_falls_back_to_the_previous_generation() {
+        let (_dir, path) = scratch();
+        let (first, second) = {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            let first = blob(&mut engine, "generation one");
+            engine.commit().unwrap();
+            let second = blob(&mut engine, "generation two");
+            engine.commit().unwrap();
+            assert_eq!(engine.generation(), 2);
+            (first, second)
+        };
+
+        // Tear the live slot, exactly as a crash mid-header-write would.
+        let live = StorageEngine::open(&path).unwrap().live_slot();
+        damage(&path, Header::slot_offset(live), &[0xAB; HEADER_SIZE]);
+
+        // The older slot still describes a complete, consistent database.
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.generation(), 1);
+        assert_eq!(engine.read(first).unwrap(), b"generation one");
+        assert!(matches!(engine.read(second), Err(CndbError::NotFound(_))));
+        engine.verify().unwrap();
+    }
+
+    #[test]
+    fn recovery_still_works_after_writing_over_the_torn_slot() {
+        let (_dir, path) = scratch();
+        {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            blob(&mut engine, "one");
+            engine.commit().unwrap();
+            blob(&mut engine, "two");
+            engine.commit().unwrap();
+        }
+
+        let live = StorageEngine::open(&path).unwrap().live_slot();
+        damage(&path, Header::slot_offset(live), &[0u8; HEADER_SIZE]);
+
+        // Recover, then commit again: the freed slot is reclaimed first.
+        let mut engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.generation(), 1);
+        let id = blob(&mut engine, "three");
+        engine.commit().unwrap();
+        assert_eq!(engine.generation(), 2);
+        assert_eq!(engine.live_slot(), live);
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.read(id).unwrap(), b"three");
+    }
+
+    #[test]
+    fn both_headers_destroyed_is_reported_clearly() {
+        let (_dir, path) = scratch();
+        {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            blob(&mut engine, "x");
+            engine.commit().unwrap();
+        }
+        damage(&path, 0, &[0x7Fu8; HEADER_SIZE * HEADER_SLOTS]);
+        assert!(matches!(
+            StorageEngine::open(&path),
+            Err(CndbError::BadMagic { .. })
+        ));
+    }
+
+    #[test]
+    fn a_foreign_file_is_rejected_as_not_a_database() {
+        let (_dir, path) = scratch();
+        std::fs::write(&path, vec![b'z'; 4096]).unwrap();
+        assert!(matches!(
+            StorageEngine::open(&path),
+            Err(CndbError::BadMagic { .. })
+        ));
+    }
+
+    #[test]
+    fn a_file_too_short_to_hold_headers_is_rejected() {
+        let (_dir, path) = scratch();
+        std::fs::write(&path, b"CNDB").unwrap();
+        assert!(matches!(
+            StorageEngine::open(&path),
+            Err(CndbError::UnexpectedEof { .. })
+        ));
+    }
+
+    #[test]
+    fn a_truncated_file_is_rejected_rather_than_half_read() {
+        let (_dir, path) = scratch();
+        {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            blob(&mut engine, "a document long enough to matter");
+            engine.commit().unwrap();
+        }
+
+        let len = std::fs::metadata(&path).unwrap().len();
+        let file = OpenOptions::new().write(true).open(&path).unwrap();
+        file.set_len(len - 16).unwrap();
+        drop(file);
+
+        assert!(matches!(
+            StorageEngine::open(&path),
+            Err(CndbError::UnexpectedEof { .. })
+        ));
+    }
+
+    #[test]
+    fn corruption_in_the_payload_is_caught_on_read() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+        let id = blob(&mut engine, "the payload we will damage");
+        engine.commit().unwrap();
+        let offset = engine.index().offset_of(id).unwrap();
+        drop(engine);
+
+        damage(&path, offset + RECORD_HEADER_SIZE + 4, b"X");
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert!(matches!(
+            engine.read(id),
+            Err(CndbError::RecordChecksum { .. })
+        ));
+        assert!(matches!(
+            engine.verify(),
+            Err(CndbError::RecordChecksum { .. })
+        ));
+    }
+
+    #[test]
+    fn tombstones_hide_documents_and_survive_a_reopen() {
+        let (_dir, path) = scratch();
+        let (kept, gone) = {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            let kept = blob(&mut engine, "keep me");
+            let gone = blob(&mut engine, "delete me");
+            engine.tombstone(gone).unwrap();
+            engine.commit().unwrap();
+
+            assert_eq!(engine.len(), 1);
+            assert!(matches!(engine.read(gone), Err(CndbError::Deleted(_))));
+            (kept, gone)
+        };
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.len(), 1);
+        assert_eq!(engine.read(kept).unwrap(), b"keep me");
+        assert!(matches!(engine.read(gone), Err(CndbError::Deleted(_))));
+    }
+
+    #[test]
+    fn deleting_twice_or_deleting_nothing_is_an_error() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+        let id = blob(&mut engine, "x");
+
+        engine.tombstone(id).unwrap();
+        assert!(matches!(engine.tombstone(id), Err(CndbError::Deleted(_))));
+        assert!(matches!(
+            engine.tombstone(DocId(9999)),
+            Err(CndbError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn the_master_index_does_not_disturb_the_record_stream() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+
+        // Commit repeatedly so several superseded master records end up sitting
+        // between the document records.
+        let mut ids = Vec::new();
+        for i in 0..5 {
+            ids.push(blob(&mut engine, &format!("round-{i}")));
+            engine.commit().unwrap();
+        }
+
+        // 5 documents + 5 master records, all framed and checksummed.
+        assert_eq!(engine.verify().unwrap(), 10);
+        for (i, id) in ids.iter().enumerate() {
+            assert_eq!(engine.read(*id).unwrap(), format!("round-{i}").as_bytes());
+        }
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.generation(), 5);
+        assert_eq!(engine.len(), 5);
+    }
+
+    #[test]
+    fn every_record_kind_roundtrips() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+
+        let node = engine.append(RecordKind::Node, b"a node").unwrap();
+        let edge = engine.append(RecordKind::Edge, b"an edge").unwrap();
+        let empty = engine.append(RecordKind::Blob, b"").unwrap();
+        engine.commit().unwrap();
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.read_record(node).unwrap().kind, RecordKind::Node);
+        assert_eq!(engine.read_record(edge).unwrap().kind, RecordKind::Edge);
+        assert_eq!(engine.read(empty).unwrap(), b"");
+    }
+
+    #[test]
+    fn large_payloads_roundtrip() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+
+        let big: Vec<u8> = (0..4 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        let id = engine.append(RecordKind::Blob, &big).unwrap();
+        engine.commit().unwrap();
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.read(id).unwrap(), big);
+    }
+
+    #[test]
+    fn oversized_payloads_are_refused() {
+        let (_dir, path) = scratch();
+        let mut engine = StorageEngine::open(&path).unwrap();
+        let too_big = vec![0u8; (MAX_RECORD_LEN + 1) as usize];
+        assert!(matches!(
+            engine.append(RecordKind::Blob, &too_big),
+            Err(CndbError::RecordTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn many_commits_keep_the_database_consistent() {
+        let (_dir, path) = scratch();
+        let mut ids = Vec::new();
+
+        for round in 0..25 {
+            let mut engine = StorageEngine::open(&path).unwrap();
+            ids.push(blob(&mut engine, &format!("round-{round}")));
+            if round % 4 == 0 {
+                engine.tombstone(ids[0]).ok();
+            }
+            engine.commit().unwrap();
+            engine.verify().unwrap();
+        }
+
+        let engine = StorageEngine::open(&path).unwrap();
+        assert_eq!(engine.generation(), 25);
+        assert_eq!(engine.len(), 24);
+        assert_eq!(engine.live_ids().count(), 24);
+    }
 }

--- a/src/storage/file_format.rs
+++ b/src/storage/file_format.rs
@@ -3,4 +3,3 @@
 pub struct FileFormat {
     // File format implementation will go here
 }
-

--- a/src/storage/file_format.rs
+++ b/src/storage/file_format.rs
@@ -1,5 +1,0 @@
-// File format handling for cndb storage
-
-pub struct FileFormat {
-    // File format implementation will go here
-}

--- a/src/storage/header.rs
+++ b/src/storage/header.rs
@@ -1,0 +1,273 @@
+//! The file header and its two-slot commit protocol.
+//!
+//! A `.cndb` file opens with two fixed 64-byte header slots. A commit writes a
+//! header with an incremented generation into whichever slot is *older*, so the
+//! previous generation's header stays intact for the entire write. On open both
+//! slots are read and the valid one with the highest generation wins.
+//!
+//! This replaces overwriting a single header in place (issue #1 §4.3). A 64-byte
+//! write inside one sector is atomic on real hardware, but that is a hardware
+//! assumption rather than a guarantee; ping-pong makes a torn header a
+//! recoverable event instead of a corrupt database.
+
+use crate::error::{CndbError, Result};
+
+/// Magic bytes opening every cndb file.
+pub const MAGIC: [u8; 4] = *b"CNDB";
+
+/// On-disk format version, `0.3.0`.
+pub const FORMAT_VERSION: u32 = 0x0003_0000;
+
+/// Size of a single header slot.
+pub const HEADER_SIZE: usize = 64;
+
+/// Number of header slots.
+pub const HEADER_SLOTS: usize = 2;
+
+/// Bytes reserved for headers; also the offset of the first log record.
+pub const LOG_START: u64 = (HEADER_SIZE * HEADER_SLOTS) as u64;
+
+/// Byte range of the checksum field, zeroed while the checksum is computed.
+const CRC_RANGE: std::ops::Range<usize> = 40..44;
+
+/// A decoded header slot.
+///
+/// Layout, little-endian:
+///
+/// | range   | field        |
+/// |---------|--------------|
+/// | `0..4`  | magic        |
+/// | `4..8`  | version      |
+/// | `8..16` | generation   |
+/// | `16..24`| master_ptr   |
+/// | `24..32`| master_len   |
+/// | `32..40`| log_end      |
+/// | `40..44`| crc32        |
+/// | `44..64`| reserved     |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Header {
+    /// Monotonic commit counter. The highest valid one is the live database.
+    pub generation: u64,
+    /// Offset of the master index record, or 0 when none has been written.
+    pub master_ptr: u64,
+    /// Length of the master index payload, or 0 when none has been written.
+    pub master_len: u64,
+    /// First free byte of the log. The next append starts here.
+    pub log_end: u64,
+}
+
+impl Header {
+    /// The header of a freshly created, empty database.
+    pub fn initial() -> Self {
+        Header {
+            generation: 0,
+            master_ptr: 0,
+            master_len: 0,
+            log_end: LOG_START,
+        }
+    }
+
+    /// Serialize to its fixed 64-byte on-disk form, checksum included.
+    pub fn encode(&self) -> [u8; HEADER_SIZE] {
+        let mut buf = [0u8; HEADER_SIZE];
+        buf[0..4].copy_from_slice(&MAGIC);
+        buf[4..8].copy_from_slice(&FORMAT_VERSION.to_le_bytes());
+        buf[8..16].copy_from_slice(&self.generation.to_le_bytes());
+        buf[16..24].copy_from_slice(&self.master_ptr.to_le_bytes());
+        buf[24..32].copy_from_slice(&self.master_len.to_le_bytes());
+        buf[32..40].copy_from_slice(&self.log_end.to_le_bytes());
+        // CRC field stays zero while the checksum is computed over the whole
+        // slot, so reserved bytes are covered too.
+        let crc = crc32fast::hash(&buf);
+        buf[CRC_RANGE].copy_from_slice(&crc.to_le_bytes());
+        buf
+    }
+
+    /// Parse a header slot, validating magic, version and checksum.
+    ///
+    /// `slot` only labels errors.
+    pub fn decode(buf: &[u8; HEADER_SIZE], slot: usize) -> Result<Self> {
+        let magic: [u8; 4] = buf[0..4].try_into().expect("4 bytes");
+        if magic != MAGIC {
+            return Err(CndbError::BadMagic {
+                expected: MAGIC,
+                found: magic,
+            });
+        }
+
+        let stored_crc = u32::from_le_bytes(buf[CRC_RANGE].try_into().expect("4 bytes"));
+        let mut probe = *buf;
+        probe[CRC_RANGE].fill(0);
+        if crc32fast::hash(&probe) != stored_crc {
+            return Err(CndbError::HeaderChecksum { slot });
+        }
+
+        let version = u32::from_le_bytes(buf[4..8].try_into().expect("4 bytes"));
+        if version != FORMAT_VERSION {
+            return Err(CndbError::UnsupportedVersion {
+                found: version,
+                supported: FORMAT_VERSION,
+            });
+        }
+
+        Ok(Header {
+            generation: u64::from_le_bytes(buf[8..16].try_into().expect("8 bytes")),
+            master_ptr: u64::from_le_bytes(buf[16..24].try_into().expect("8 bytes")),
+            master_len: u64::from_le_bytes(buf[24..32].try_into().expect("8 bytes")),
+            log_end: u64::from_le_bytes(buf[32..40].try_into().expect("8 bytes")),
+        })
+    }
+
+    /// Byte offset of a header slot.
+    pub fn slot_offset(slot: usize) -> u64 {
+        debug_assert!(slot < HEADER_SLOTS);
+        (slot * HEADER_SIZE) as u64
+    }
+}
+
+/// Pick the live header from the decoded slots.
+///
+/// Takes the valid slot with the highest generation. Returns `NoValidHeader`
+/// only when every slot failed to decode, which means the file is not a cndb
+/// database or both headers are damaged.
+pub fn select_live(slots: &[Option<Header>; HEADER_SLOTS]) -> Result<(Header, usize)> {
+    slots
+        .iter()
+        .enumerate()
+        .filter_map(|(i, h)| h.map(|h| (h, i)))
+        .max_by_key(|(h, _)| h.generation)
+        .ok_or(CndbError::NoValidHeader)
+}
+
+/// The slot a commit should overwrite: any invalid slot, else the oldest.
+///
+/// Never returns the live slot, so the live header survives the write.
+pub fn victim_slot(slots: &[Option<Header>; HEADER_SLOTS]) -> usize {
+    if let Some(i) = slots.iter().position(|h| h.is_none()) {
+        return i;
+    }
+    slots
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, h)| h.expect("all slots valid").generation)
+        .map(|(i, _)| i)
+        .expect("at least one slot")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Header {
+        Header {
+            generation: 7,
+            master_ptr: 4096,
+            master_len: 512,
+            log_end: 4608,
+        }
+    }
+
+    #[test]
+    fn layout_is_exactly_one_slot() {
+        assert_eq!(sample().encode().len(), HEADER_SIZE);
+        assert_eq!(LOG_START, 128);
+    }
+
+    #[test]
+    fn roundtrips() {
+        let h = sample();
+        assert_eq!(Header::decode(&h.encode(), 0).unwrap(), h);
+    }
+
+    #[test]
+    fn initial_header_points_past_the_header_region() {
+        let h = Header::initial();
+        assert_eq!(h.log_end, LOG_START);
+        assert_eq!(h.master_len, 0);
+        assert_eq!(Header::decode(&h.encode(), 0).unwrap(), h);
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut buf = sample().encode();
+        buf[0] = b'X';
+        assert!(matches!(
+            Header::decode(&buf, 0),
+            Err(CndbError::BadMagic { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_version() {
+        let mut h = sample().encode();
+        h[4..8].copy_from_slice(&0x0002_0000u32.to_le_bytes());
+        // Re-checksum so version, not corruption, is what fails.
+        h[CRC_RANGE].fill(0);
+        let crc = crc32fast::hash(&h);
+        h[CRC_RANGE].copy_from_slice(&crc.to_le_bytes());
+        assert!(matches!(
+            Header::decode(&h, 0),
+            Err(CndbError::UnsupportedVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn detects_corruption_in_every_field() {
+        // Byte 40..44 is the checksum itself; corrupting it must also fail.
+        for i in 0..HEADER_SIZE {
+            let mut buf = sample().encode();
+            buf[i] ^= 0xFF;
+            let decoded = Header::decode(&buf, 0);
+            assert!(
+                decoded.is_err(),
+                "corrupting byte {i} went undetected: {decoded:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn live_slot_is_the_highest_generation() {
+        let old = Header {
+            generation: 3,
+            ..sample()
+        };
+        let new = Header {
+            generation: 4,
+            ..sample()
+        };
+        let (live, slot) = select_live(&[Some(old), Some(new)]).unwrap();
+        assert_eq!((live.generation, slot), (4, 1));
+
+        let (live, slot) = select_live(&[Some(new), Some(old)]).unwrap();
+        assert_eq!((live.generation, slot), (4, 0));
+    }
+
+    #[test]
+    fn live_slot_ignores_a_damaged_partner() {
+        let h = sample();
+        assert_eq!(select_live(&[None, Some(h)]).unwrap().1, 1);
+        assert_eq!(select_live(&[Some(h), None]).unwrap().1, 0);
+        assert!(matches!(
+            select_live(&[None, None]),
+            Err(CndbError::NoValidHeader)
+        ));
+    }
+
+    #[test]
+    fn victim_is_never_the_live_slot() {
+        let old = Header {
+            generation: 3,
+            ..sample()
+        };
+        let new = Header {
+            generation: 4,
+            ..sample()
+        };
+        // Oldest loses.
+        assert_eq!(victim_slot(&[Some(old), Some(new)]), 0);
+        assert_eq!(victim_slot(&[Some(new), Some(old)]), 1);
+        // An empty slot is claimed before a valid one is recycled.
+        assert_eq!(victim_slot(&[None, Some(new)]), 0);
+        assert_eq!(victim_slot(&[Some(new), None]), 1);
+    }
+}

--- a/src/storage/index.rs
+++ b/src/storage/index.rs
@@ -1,0 +1,175 @@
+//! The master index: every in-memory lookup structure, in one committed blob.
+//!
+//! M1 carries the document offset map (issue #7), the tombstone set and the id
+//! allocator. M2 adds the adjacency, name and full-text indexes described in
+//! `docs/ARCHITECTURE.md` §3.3 as further fields here.
+//!
+//! bincode is not self-describing, so adding a field breaks compatibility with
+//! older files. `FORMAT_VERSION` in the header is what guards that: a file
+//! written by an older layout is rejected at open rather than misread.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{CndbError, Result};
+use crate::storage::record::DocId;
+
+/// All indexes, serialized as one record on each commit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MasterIndex {
+    /// Document id to its byte offset in the log.
+    pub offsets: HashMap<DocId, u64>,
+    /// Documents tombstoned but not yet compacted away.
+    pub dead: HashSet<DocId>,
+    /// Next id to hand out. Never reused, even after a delete.
+    pub next_doc_id: u64,
+}
+
+impl Default for MasterIndex {
+    fn default() -> Self {
+        MasterIndex {
+            offsets: HashMap::new(),
+            dead: HashSet::new(),
+            // Ids start at 1 so 0 stays available as a niche/sentinel.
+            next_doc_id: 1,
+        }
+    }
+}
+
+impl MasterIndex {
+    /// Reserve the next document id.
+    pub fn allocate_id(&mut self) -> DocId {
+        let id = DocId(self.next_doc_id);
+        self.next_doc_id += 1;
+        id
+    }
+
+    /// Record where a document landed.
+    pub fn insert(&mut self, id: DocId, offset: u64) {
+        self.offsets.insert(id, offset);
+    }
+
+    /// Offset of a live document, or `None` if unknown or deleted.
+    pub fn offset_of(&self, id: DocId) -> Option<u64> {
+        if self.dead.contains(&id) {
+            return None;
+        }
+        self.offsets.get(&id).copied()
+    }
+
+    /// True if the id exists and has not been deleted.
+    pub fn is_live(&self, id: DocId) -> bool {
+        self.offsets.contains_key(&id) && !self.dead.contains(&id)
+    }
+
+    /// Number of live documents.
+    pub fn live_count(&self) -> usize {
+        self.offsets.len() - self.dead.len()
+    }
+
+    /// Number of tombstoned documents awaiting compaction.
+    pub fn dead_count(&self) -> usize {
+        self.dead.len()
+    }
+
+    /// Share of stored documents that are tombstones, 0.0 when empty.
+    ///
+    /// M5 compacts once this crosses its threshold.
+    pub fn dead_ratio(&self) -> f64 {
+        if self.offsets.is_empty() {
+            return 0.0;
+        }
+        self.dead.len() as f64 / self.offsets.len() as f64
+    }
+
+    /// Every live document id, in no particular order.
+    pub fn live_ids(&self) -> impl Iterator<Item = DocId> + '_ {
+        self.offsets
+            .keys()
+            .copied()
+            .filter(|id| !self.dead.contains(id))
+    }
+
+    /// Serialize for the master index record.
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        bincode::serialize(self).map_err(|e| CndbError::CorruptIndex(e.to_string()))
+    }
+
+    /// Deserialize from a master index record payload.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        bincode::deserialize(bytes).map_err(|e| CndbError::CorruptIndex(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_start_at_one_and_never_repeat() {
+        let mut idx = MasterIndex::default();
+        assert_eq!(idx.allocate_id(), DocId(1));
+        assert_eq!(idx.allocate_id(), DocId(2));
+
+        idx.insert(DocId(1), 128);
+        idx.dead.insert(DocId(1));
+        // Deleting does not free the id for reuse.
+        assert_eq!(idx.allocate_id(), DocId(3));
+    }
+
+    #[test]
+    fn tombstones_hide_documents_without_losing_the_offset() {
+        let mut idx = MasterIndex::default();
+        idx.insert(DocId(1), 128);
+        assert_eq!(idx.offset_of(DocId(1)), Some(128));
+        assert!(idx.is_live(DocId(1)));
+
+        idx.dead.insert(DocId(1));
+        assert_eq!(idx.offset_of(DocId(1)), None);
+        assert!(!idx.is_live(DocId(1)));
+        // The offset survives so compaction can still find the record.
+        assert_eq!(idx.offsets.get(&DocId(1)), Some(&128));
+    }
+
+    #[test]
+    fn counts_and_ratio_track_tombstones() {
+        let mut idx = MasterIndex::default();
+        assert_eq!(idx.dead_ratio(), 0.0, "empty index must not divide by zero");
+
+        for i in 1..=4u64 {
+            idx.insert(DocId(i), i * 100);
+        }
+        assert_eq!((idx.live_count(), idx.dead_count()), (4, 0));
+
+        idx.dead.insert(DocId(1));
+        assert_eq!((idx.live_count(), idx.dead_count()), (3, 1));
+        assert_eq!(idx.dead_ratio(), 0.25);
+
+        let mut live: Vec<_> = idx.live_ids().map(|d| d.0).collect();
+        live.sort_unstable();
+        assert_eq!(live, vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn roundtrips_through_bincode() {
+        let mut idx = MasterIndex::default();
+        for i in 1..=32u64 {
+            let id = idx.allocate_id();
+            idx.insert(id, i * 137);
+        }
+        idx.dead.insert(DocId(3));
+
+        assert_eq!(MasterIndex::decode(&idx.encode().unwrap()).unwrap(), idx);
+    }
+
+    #[test]
+    fn rejects_a_truncated_blob() {
+        let idx = MasterIndex::default();
+        let bytes = idx.encode().unwrap();
+        assert!(matches!(
+            MasterIndex::decode(&bytes[..bytes.len() / 2]),
+            Err(CndbError::CorruptIndex(_))
+        ));
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,15 @@
-// Storage module for cndb
+//! The storage engine: a single file, an append-only log, and an atomically
+//! committed index.
+//!
+//! See `docs/ARCHITECTURE.md` §3 for the file layout and commit protocol.
 
 pub mod engine;
-pub mod file_format;
+pub mod header;
+pub mod index;
+mod pos_io;
+pub mod record;
 
-pub use engine::*;
-pub use file_format::*;
+pub use engine::{Stats, StorageEngine};
+pub use header::{Header, FORMAT_VERSION, HEADER_SIZE, HEADER_SLOTS, LOG_START, MAGIC};
+pub use index::MasterIndex;
+pub use record::{DocId, Record, RecordKind, MAX_RECORD_LEN, RECORD_HEADER_SIZE};

--- a/src/storage/pos_io.rs
+++ b/src/storage/pos_io.rs
@@ -1,0 +1,64 @@
+//! Positioned file I/O.
+//!
+//! Reads and writes take an explicit offset and never touch the file cursor, so
+//! reads can borrow the file immutably. That keeps `StorageEngine::read` on
+//! `&self` today and leaves room for the single-writer/multiple-reader model on
+//! the roadmap without an API break.
+//!
+//! `std` spells positioned I/O differently on each platform, so both are
+//! wrapped here rather than at every call site.
+
+use std::fs::File;
+use std::io;
+
+#[cfg(unix)]
+pub fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.read_exact_at(buf, offset)
+}
+
+#[cfg(unix)]
+pub fn write_all_at(file: &File, buf: &[u8], offset: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.write_all_at(buf, offset)
+}
+
+#[cfg(windows)]
+pub fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    let mut done = 0usize;
+    while done < buf.len() {
+        match file.seek_read(&mut buf[done..], offset + done as u64) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "failed to fill whole buffer",
+                ))
+            }
+            Ok(n) => done += n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn write_all_at(file: &File, buf: &[u8], offset: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    let mut done = 0usize;
+    while done < buf.len() {
+        match file.seek_write(&buf[done..], offset + done as u64) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write whole buffer",
+                ))
+            }
+            Ok(n) => done += n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}

--- a/src/storage/record.rs
+++ b/src/storage/record.rs
@@ -1,0 +1,217 @@
+//! Record framing for the append-only log.
+//!
+//! Every record is `[len: u32][kind: u8][crc32: u32][payload]`, little-endian,
+//! with the checksum taken over the payload alone.
+//!
+//! Issue #1 framed records as `[len][BSON]` and issue #2 as
+//! `[len][collection][BSON]`. Neither carries a checksum, so a partially
+//! written or bit-rotted record deserializes into plausible garbage instead of
+//! failing. The kind tag replaces the inline collection name: it is one byte
+//! rather than a length-prefixed string, and it lets the master index be
+//! written into the same log as a well-framed record that scans skip over.
+
+use crate::error::{CndbError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Bytes of framing preceding every payload.
+pub const RECORD_HEADER_SIZE: u64 = 9;
+
+/// Largest payload accepted, a guard against absurd allocations when framing is
+/// corrupt.
+pub const MAX_RECORD_LEN: u64 = 64 * 1024 * 1024;
+
+/// Identifier of a stored document, unique for the life of the database.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
+pub struct DocId(pub u64);
+
+impl std::fmt::Display for DocId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{}", self.0)
+    }
+}
+
+/// What a record holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum RecordKind {
+    /// A graph node. Written from M2 onward.
+    Node = 0,
+    /// A graph edge. Written from M2 onward.
+    Edge = 1,
+    /// An unstructured document.
+    Blob = 2,
+    /// Marks an earlier record dead. Payload is the target `DocId`.
+    Tombstone = 3,
+    /// A serialized master index, written by every commit.
+    MasterIndex = 4,
+}
+
+impl RecordKind {
+    /// Parse a kind tag. `offset` only labels errors.
+    pub fn from_tag(tag: u8, offset: u64) -> Result<Self> {
+        match tag {
+            0 => Ok(RecordKind::Node),
+            1 => Ok(RecordKind::Edge),
+            2 => Ok(RecordKind::Blob),
+            3 => Ok(RecordKind::Tombstone),
+            4 => Ok(RecordKind::MasterIndex),
+            kind => Err(CndbError::UnknownRecordKind { kind, offset }),
+        }
+    }
+
+    /// True for records that carry user data rather than engine bookkeeping.
+    pub fn is_document(self) -> bool {
+        matches!(self, RecordKind::Node | RecordKind::Edge | RecordKind::Blob)
+    }
+}
+
+/// A record read back out of the log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Record {
+    pub kind: RecordKind,
+    pub payload: Vec<u8>,
+}
+
+/// Build the 9-byte frame preceding `payload`.
+pub fn encode_frame(kind: RecordKind, payload: &[u8]) -> [u8; RECORD_HEADER_SIZE as usize] {
+    let mut frame = [0u8; RECORD_HEADER_SIZE as usize];
+    frame[0..4].copy_from_slice(&(payload.len() as u32).to_le_bytes());
+    frame[4] = kind as u8;
+    frame[5..9].copy_from_slice(&crc32fast::hash(payload).to_le_bytes());
+    frame
+}
+
+/// A parsed frame, before its payload is read.
+#[derive(Debug, Clone, Copy)]
+pub struct Frame {
+    pub len: u64,
+    pub kind: RecordKind,
+    pub crc: u32,
+}
+
+impl Frame {
+    /// Total on-disk size of the record, framing included.
+    pub fn total_len(&self) -> u64 {
+        RECORD_HEADER_SIZE + self.len
+    }
+}
+
+/// Parse a frame read from `offset`.
+pub fn decode_frame(buf: &[u8; RECORD_HEADER_SIZE as usize], offset: u64) -> Result<Frame> {
+    let len = u32::from_le_bytes(buf[0..4].try_into().expect("4 bytes")) as u64;
+    if len > MAX_RECORD_LEN {
+        return Err(CndbError::RecordTooLarge {
+            offset,
+            len,
+            max: MAX_RECORD_LEN,
+        });
+    }
+    Ok(Frame {
+        len,
+        kind: RecordKind::from_tag(buf[4], offset)?,
+        crc: u32::from_le_bytes(buf[5..9].try_into().expect("4 bytes")),
+    })
+}
+
+/// Verify a payload against the checksum in its frame.
+pub fn verify_payload(frame: &Frame, payload: &[u8], offset: u64) -> Result<()> {
+    if crc32fast::hash(payload) != frame.crc {
+        return Err(CndbError::RecordChecksum { offset });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_roundtrips() {
+        let payload = b"the quick brown fox";
+        let frame = encode_frame(RecordKind::Blob, payload);
+        let decoded = decode_frame(&frame, 128).unwrap();
+
+        assert_eq!(decoded.len, payload.len() as u64);
+        assert_eq!(decoded.kind, RecordKind::Blob);
+        assert_eq!(
+            decoded.total_len(),
+            RECORD_HEADER_SIZE + payload.len() as u64
+        );
+        verify_payload(&decoded, payload, 128).unwrap();
+    }
+
+    #[test]
+    fn empty_payload_is_legal() {
+        let frame = encode_frame(RecordKind::Tombstone, &[]);
+        let decoded = decode_frame(&frame, 0).unwrap();
+        assert_eq!(decoded.len, 0);
+        verify_payload(&decoded, &[], 0).unwrap();
+    }
+
+    #[test]
+    fn detects_a_single_flipped_bit_in_the_payload() {
+        let payload = b"cndb storage core".to_vec();
+        let frame = decode_frame(&encode_frame(RecordKind::Blob, &payload), 0).unwrap();
+
+        for i in 0..payload.len() {
+            let mut corrupt = payload.clone();
+            corrupt[i] ^= 0x01;
+            assert!(
+                matches!(
+                    verify_payload(&frame, &corrupt, 0),
+                    Err(CndbError::RecordChecksum { .. })
+                ),
+                "flipping a bit in byte {i} went undetected"
+            );
+        }
+    }
+
+    #[test]
+    fn every_kind_survives_its_tag() {
+        for kind in [
+            RecordKind::Node,
+            RecordKind::Edge,
+            RecordKind::Blob,
+            RecordKind::Tombstone,
+            RecordKind::MasterIndex,
+        ] {
+            let frame = decode_frame(&encode_frame(kind, b"x"), 0).unwrap();
+            assert_eq!(frame.kind, kind);
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_kinds() {
+        // 5..=255 are unallocated and reserved for later record types.
+        let mut frame = encode_frame(RecordKind::Blob, b"x");
+        frame[4] = 5;
+        assert!(matches!(
+            decode_frame(&frame, 64),
+            Err(CndbError::UnknownRecordKind {
+                kind: 5,
+                offset: 64
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_absurd_lengths_before_allocating() {
+        let mut frame = encode_frame(RecordKind::Blob, b"x");
+        frame[0..4].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(matches!(
+            decode_frame(&frame, 0),
+            Err(CndbError::RecordTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn only_user_data_counts_as_a_document() {
+        assert!(RecordKind::Node.is_document());
+        assert!(RecordKind::Edge.is_document());
+        assert!(RecordKind::Blob.is_document());
+        assert!(!RecordKind::Tombstone.is_document());
+        assert!(!RecordKind::MasterIndex.is_document());
+    }
+}

--- a/src/vector/embeddings.rs
+++ b/src/vector/embeddings.rs
@@ -3,4 +3,3 @@
 pub struct Embeddings {
     // Embeddings implementation will go here
 }
-

--- a/src/vector/embeddings.rs
+++ b/src/vector/embeddings.rs
@@ -1,5 +1,0 @@
-// Embeddings handling for cndb
-
-pub struct Embeddings {
-    // Embeddings implementation will go here
-}

--- a/src/vector/index.rs
+++ b/src/vector/index.rs
@@ -3,4 +3,3 @@
 pub struct VectorIndex {
     // Vector index implementation will go here
 }
-

--- a/src/vector/index.rs
+++ b/src/vector/index.rs
@@ -1,5 +1,0 @@
-// Vector index implementation for cndb
-
-pub struct VectorIndex {
-    // Vector index implementation will go here
-}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,7 +1,0 @@
-// Vector module for cndb
-
-pub mod embeddings;
-pub mod index;
-
-pub use embeddings::*;
-pub use index::*;

--- a/tests/durability.rs
+++ b/tests/durability.rs
@@ -1,0 +1,238 @@
+//! End-to-end durability and portability tests.
+//!
+//! These cover the storage-engine half of the success criteria in
+//! `docs/ARCHITECTURE.md` §7.2 — C8 (a crash during commit is always
+//! recoverable) and C9 (the file copies between machines).
+
+use cndb::{Cndb, CndbError, DocId, StorageEngine, FORMAT_VERSION};
+use serde_json::json;
+use tempfile::TempDir;
+
+/// Build a database with several committed generations and some deletions.
+/// Returns the ids expected to be readable afterwards.
+fn populate(path: &std::path::Path) -> Vec<DocId> {
+    let mut db = Cndb::open(path).unwrap();
+    let mut live = Vec::new();
+
+    for round in 0..6 {
+        for i in 0..4 {
+            let id = db
+                .insert(&json!({
+                    "round": round,
+                    "kind": "Function",
+                    "qualified_name": format!("cndb::round{round}::symbol_{i}"),
+                    "span": { "start_line": round * 10 + i, "end_line": round * 10 + i + 5 },
+                }))
+                .unwrap();
+            live.push(id);
+        }
+        // Delete one document from an earlier round, so tombstones are part of
+        // the committed state rather than an untested edge case.
+        if round > 0 {
+            let victim = live.remove(0);
+            db.delete(victim).unwrap();
+        }
+        db.commit().unwrap();
+    }
+
+    live
+}
+
+#[test]
+fn c9_the_file_is_self_contained_and_portable() {
+    let dir = TempDir::new().unwrap();
+    let original = dir.path().join("graph.cndb");
+    let live = populate(&original);
+
+    // Copying the raw bytes is what moving between machines amounts to.
+    let copy = dir.path().join("copied.cndb");
+    std::fs::copy(&original, &copy).unwrap();
+
+    let db = Cndb::open(&copy).unwrap();
+    assert_eq!(db.len(), live.len());
+    db.verify().unwrap();
+    for id in &live {
+        let doc = db.get(*id).unwrap();
+        assert_eq!(doc["kind"], "Function");
+        assert!(doc["qualified_name"]
+            .as_str()
+            .unwrap()
+            .starts_with("cndb::"));
+    }
+}
+
+#[test]
+fn c8_a_crash_at_any_byte_never_yields_a_corrupt_database() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("graph.cndb");
+    populate(&source);
+
+    let bytes = std::fs::read(&source).unwrap();
+    let scratch = dir.path().join("prefix.cndb");
+
+    // A crash leaves some prefix of the intended writes on disk. Every prefix
+    // must either be rejected outright or open into a fully consistent
+    // database. What must never happen is opening and then handing back
+    // damaged data.
+    let mut opened = 0;
+    for len in 0..=bytes.len() {
+        std::fs::write(&scratch, &bytes[..len]).unwrap();
+
+        let db = match Cndb::open(&scratch) {
+            Ok(db) => db,
+            Err(_) => continue,
+        };
+        opened += 1;
+
+        // Whatever it claims to hold must actually be readable and intact.
+        db.verify()
+            .unwrap_or_else(|e| panic!("prefix of {len} bytes opened but failed verify: {e}"));
+        for id in db.ids() {
+            db.get(id)
+                .unwrap_or_else(|e| panic!("prefix of {len} bytes: {id} unreadable: {e}"));
+        }
+    }
+
+    assert!(
+        opened > 1,
+        "expected several prefixes to be recoverable, only {opened} were"
+    );
+}
+
+#[test]
+fn a_zero_length_prefix_is_treated_as_a_new_database_not_a_corrupt_one() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("empty.cndb");
+    std::fs::write(&path, b"").unwrap();
+
+    let db = Cndb::open(&path).unwrap();
+    assert!(db.is_empty());
+    assert_eq!(db.stats().generation, 0);
+}
+
+#[test]
+fn the_on_disk_layout_is_stable() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("layout.cndb");
+    {
+        let mut db = Cndb::open(&path).unwrap();
+        db.insert(&json!({ "x": 1 })).unwrap();
+        db.commit().unwrap();
+    }
+
+    let bytes = std::fs::read(&path).unwrap();
+
+    // Guards against silent format drift: a change here must be a deliberate
+    // version bump, not a side effect of refactoring.
+    assert_eq!(&bytes[0..4], b"CNDB", "magic bytes moved");
+    assert_eq!(
+        u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+        FORMAT_VERSION,
+        "version field moved or changed"
+    );
+    // Slot B carries its own magic once the first commit lands there.
+    assert_eq!(&bytes[64..68], b"CNDB", "second header slot moved");
+    assert!(
+        bytes.len() > 128,
+        "records must start after both header slots"
+    );
+}
+
+#[test]
+fn a_database_written_by_a_future_version_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("future.cndb");
+    {
+        let mut db = Cndb::open(&path).unwrap();
+        db.insert(&json!({ "x": 1 })).unwrap();
+        db.commit().unwrap();
+    }
+
+    // Rewrite both version fields, re-checksumming so the version is what
+    // fails rather than corruption.
+    let mut bytes = std::fs::read(&path).unwrap();
+    for slot in 0..2 {
+        let base = slot * 64;
+        bytes[base + 4..base + 8].copy_from_slice(&0x0009_0000u32.to_le_bytes());
+        bytes[base + 40..base + 44].fill(0);
+        let crc = crc32fast::hash(&bytes[base..base + 64]);
+        bytes[base + 40..base + 44].copy_from_slice(&crc.to_le_bytes());
+    }
+    std::fs::write(&path, &bytes).unwrap();
+
+    assert!(matches!(
+        Cndb::open(&path),
+        Err(CndbError::UnsupportedVersion { .. })
+    ));
+}
+
+#[test]
+fn reopening_repeatedly_does_not_grow_the_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("stable.cndb");
+    populate(&path);
+
+    let size = std::fs::metadata(&path).unwrap().len();
+    for _ in 0..10 {
+        let db = StorageEngine::open(&path).unwrap();
+        db.verify().unwrap();
+    }
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().len(),
+        size,
+        "opening without writing must not touch the file"
+    );
+}
+
+/// Abandoned writes are reclaimed *logically* — the next commit overwrites
+/// them — but the engine never shortens the file, so its length stays at the
+/// high-water mark. Physically returning that space is compaction's job (M5).
+///
+/// What matters here is that repeated crashes do not leak: the committed
+/// region must stay small, and the file must not grow once per crash.
+#[test]
+fn abandoned_writes_are_overwritten_rather_than_leaked() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("reuse.cndb");
+
+    let junk = json!({ "discard": "x".repeat(200) });
+
+    // Five separate crash-and-recover cycles, each abandoning the same volume.
+    let mut high_water = 0;
+    for cycle in 0..5 {
+        let mut db = Cndb::open(&path).unwrap();
+        db.insert(&json!({ "cycle": cycle })).unwrap();
+        db.commit().unwrap();
+
+        for _ in 0..50 {
+            db.insert(&junk).unwrap();
+        }
+        drop(db); // crash: flushed, never committed
+
+        let size = std::fs::metadata(&path).unwrap().len();
+        if cycle == 0 {
+            high_water = size;
+        }
+    }
+
+    let db = Cndb::open(&path).unwrap();
+    db.verify().unwrap();
+    assert_eq!(db.len(), 5, "one surviving document per cycle");
+
+    // Each cycle reuses the previous cycle's abandoned bytes, so the file sits
+    // near a single cycle's high-water mark rather than five times it.
+    let final_size = std::fs::metadata(&path).unwrap().len();
+    assert!(
+        final_size < high_water * 2,
+        "file grew to {final_size} against a one-cycle mark of {high_water}: \
+         abandoned bytes are leaking, not being reused"
+    );
+
+    // The committed region is a small fraction of the physical file — the
+    // abandoned tail is beyond it and is never read back.
+    let committed = db.stats().committed_len;
+    assert!(
+        committed * 4 < final_size,
+        "committed region {committed} should be far smaller than the file {final_size}"
+    );
+}


### PR DESCRIPTION
Redefine cndb as a single-file, embedded graph knowledge base that indexes
a repository's structure for coding agents, replacing the v0.2.0 hybrid
document+vector database aimed at an e-commerce OLTP workload.

The storage thesis is unchanged: one portable file, local-first, append-only
log with an atomically committed index block, custom binary format with no
third-party database underneath. What changes is the data model (documents
to nodes+edges) and the workload (concurrent OLTP to graph traversal).

Add docs/ARCHITECTURE.md covering:
- the three engines: extract (tree-sitter), graph, and query
- file format with two-slot header ping-pong for atomic commit, replacing
  the single in-place header overwrite
- adjacency and name indexes in the master block, so traversal reads the
  index rather than scanning edge documents
- node/edge schema with extracted-vs-inferred confidence on every edge
- CLI plus in-process library surface, deliberately not MCP
- roadmap mapping existing issues to milestones, and success criteria
  measured on real repositories instead of synthetic data

Drop rust-bert and hnsw. rust-bert pulls torch-sys, whose build script
downloads libtorch; it currently fails to build, leaving CI red on main.
It also rules out the single portable binary the project depends on.
Vectors return in v1 on a statically linked ONNX/Candle backend.

Also fix pre-existing cargo fmt --check failures from trailing blank lines.
Build, clippy, fmt and tests now all pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BxmxC2UXL3JwQcDJFhkXBo